### PR TITLE
Add support to Fullscreen shorcut and menu item

### DIFF
--- a/app/hyperterm.js
+++ b/app/hyperterm.js
@@ -42,6 +42,7 @@ export default class HyperTerm extends Component {
 
     this.moveLeft = this.moveLeft.bind(this);
     this.moveRight = this.moveRight.bind(this);
+    this.fullscreen = this.fullscreen.bind(this);
   }
 
   render () {
@@ -214,6 +215,7 @@ export default class HyperTerm extends Component {
 
     this.rpc.on('move left', this.moveLeft);
     this.rpc.on('move right', this.moveRight);
+    this.rpc.on('fullscreen', this.fullscreen);
 
     Mousetrap.bind('command+1', this.moveTo.bind(this, 0));
     Mousetrap.bind('command+2', this.moveTo.bind(this, 1));
@@ -235,6 +237,12 @@ export default class HyperTerm extends Component {
 
     Mousetrap.bind('command+alt+left', this.moveLeft);
     Mousetrap.bind('command+alt+right', this.moveRight);
+
+    Mousetrap.bind('command+ctrl+f', this.fullscreen);
+  }
+
+  fullscreen() {
+    this.rpc.emit('fullscreen');
   }
 
   onUpdateAvailable (updateVersion) {

--- a/index.js
+++ b/index.js
@@ -98,6 +98,10 @@ app.on('ready', () => {
       shell.openExternal(url);
     });
 
+    rpc.on('fullscreen', () => {
+      win.setFullScreen(!win.isFullScreen());
+    });
+
     const deleteSessions = () => {
       sessions.forEach((session, key) => {
         session.removeAllListeners();
@@ -226,6 +230,15 @@ app.on('ready', () => {
           click (item, focusedWindow) {
             if (focusedWindow) {
               focusedWindow.rpc.emit('move right');
+            }
+          }
+        },
+        {
+          label: 'Fullscreen',
+          accelerator: 'Ctrl+Cmd+F',
+          click (item, focusedWindow) {
+            if (focusedWindow) {
+              focusedWindow.rpc.emit('fullscreen');
             }
           }
         }


### PR DESCRIPTION
This PR implements https://github.com/zeit/hyperterm/issues/1, by adding `Ctrl+Cmd+F` shortcut to switch between Window and Fullscreen modes, it also adds a Menu item under the Window menu to switch between modes