### PR TITLE
Centered traffic lights & disabled text selection for indicator

### DIFF
--- a/app/css/hyperterm.css
+++ b/app/css/hyperterm.css
@@ -43,6 +43,12 @@ header {
   display: block;
 }
 
+.resize-indicator,
+.update-indicator {
+  cursor: default;
+  -webkit-user-select: none;
+}
+
 .resize-indicator {
   background: rgba(255, 255, 255, .2);
   padding: 6px 14px;

--- a/app/css/tabs.css
+++ b/app/css/tabs.css
@@ -4,8 +4,8 @@ nav {
   "Segoe UI", "Roboto", "Oxygen",
   "Ubuntu", "Cantarell", "Fira Sans",
   "Droid Sans", "Helvetica Neue", sans-serif;
-  height: 28px;
-  line-height: 28px;
+  height: 37px;
+  line-height: 37px;
   vertical-align: middle;
   color: #9B9B9B;
   cursor: default;
@@ -19,13 +19,13 @@ nav {
 
 .tabs {
   border-bottom: 1px solid #333;
-  max-height: 28px;
+  max-height: 37px;
   display: flex;
   flex-flow: row;
 }
 
 .tabs li:first-child {
-  margin-left: 70px;
+  margin-left: 76px;
 }
 
 .tabs li {

--- a/app/hyperterm.js
+++ b/app/hyperterm.js
@@ -13,8 +13,8 @@ export default class HyperTerm extends Component {
     this.state = {
       cols: null,
       rows: null,
-      hpadding: 10,
-      vpadding: 5,
+      hpadding: 12,
+      vpadding: 19,
       sessions: [],
       titles: {},
       urls: {},

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ app.on('ready', () => {
     let win = new BrowserWindow({
       width: 540,
       height: 380,
-      titleBarStyle: 'hidden',
+      titleBarStyle: 'hidden-inset',
       title: 'HyperTerm',
       backgroundColor: '#000',
       transparent: true,


### PR DESCRIPTION
- Fixes https://github.com/zeit/hyperterm/issues/6
- Prevents the user from selecting text within the update/resize indicator. Also shows a default cursor instead of the one for text within these indicators.

How it looks (I've used Sketch.app to precisely measure the sizes/paddings):

![screen shot 2016-07-03 at 13 25 47](https://cloud.githubusercontent.com/assets/6170607/16545161/d9974522-4121-11e6-99c0-3b2d52630dda.png)
