### PR TITLE
font size improvements

### DIFF
--- a/app/css/hyperterm.css
+++ b/app/css/hyperterm.css
@@ -44,8 +44,6 @@ header {
 }
 
 .resize-indicator {
-  background: rgba(255, 255, 255, .2);
-  padding: 6px 14px;
   color: #fff;
   font: 11px Menlo;
   position: fixed;
@@ -53,6 +51,13 @@ header {
   right: 20px;
   opacity: 0;
   transition: opacity 150ms ease-in;
+  display: flex;
+}
+
+.resize-indicator > div {
+  background: rgba(255, 255, 255, .2);
+  padding: 6px 14px;
+  margin-left: 10px;
 }
 
 .resize-indicator.showing {

--- a/app/hyperterm.js
+++ b/app/hyperterm.js
@@ -22,6 +22,7 @@ export default class HyperTerm extends Component {
       activeMarkers: [],
       mac: /Mac/.test(navigator.userAgent),
       resizeIndicatorShowing: false,
+      fontSizeIndicatorShowing: false,
       updateVersion: null,
       updateNote: null,
       fontSize: 12
@@ -91,7 +92,7 @@ export default class HyperTerm extends Component {
         }</div>
       </div>
       <div className={classes('resize-indicator', { showing: this.state.resizeIndicatorShowing })}>
-        <div>{ this.state.fontSize }px</div>
+        {this.state.fontSizeIndicatorShowing && <div>{ this.state.fontSize }px</div>}
         <div>{ this.state.cols }x{ this.state.rows }</div>
       </div>
       <div className={classes('update-indicator', { showing: null !== this.state.updateVersion })}>
@@ -272,21 +273,28 @@ export default class HyperTerm extends Component {
     }
   }
 
-  changeFontSize (value) {
-    this.setState({ fontSize: this.state.fontSize + value });
+  changeFontSize (value, increment = false) {
+    this.setState({
+      fontSize: increment ? this.state.fontSize + value : value,
+      fontSizeIndicatorShowing: true
+    });
+
+    clearTimeout(this.fontSizeIndicatorTimeout);
+    this.fontSizeIndicatorTimeout = setTimeout(() => {
+      this.setState({ fontSizeIndicatorShowing: false });
+    }, 1500);
   }
 
   resetFontSize () {
-    // TODO: once we have preferences, we need to read from it
-    this.setState({ fontSize: 12 });
+    this.changeFontSize(12);
   }
 
   increaseFontSize () {
-    this.changeFontSize(1);
+    this.changeFontSize(1, true);
   }
 
   decreaseFontSize () {
-    this.changeFontSize(-1);
+    this.changeFontSize(-1, true);
   }
 
   onSessionExit ({ uid }) {

--- a/app/hyperterm.js
+++ b/app/hyperterm.js
@@ -367,9 +367,6 @@ export default class HyperTerm extends Component {
       keys.bind('command+shift+]', this.moveRight);
       keys.bind('command+alt+left', this.moveLeft);
       keys.bind('command+alt+right', this.moveRight);
-      keys.bind('command+plus', this.increaseFontSize);
-      keys.bind('command+minus', this.decreaseFontSize);
-      keys.bind('command+0', this.resetFontSize);
 
       this.keys = keys;
     }

--- a/app/hyperterm.js
+++ b/app/hyperterm.js
@@ -273,9 +273,9 @@ export default class HyperTerm extends Component {
     }
   }
 
-  changeFontSize (value, increment = false) {
+  changeFontSize (value, { relative = false } = {}) {
     this.setState({
-      fontSize: increment ? this.state.fontSize + value : value,
+      fontSize: relative ? this.state.fontSize + value : value,
       fontSizeIndicatorShowing: true
     });
 
@@ -290,11 +290,11 @@ export default class HyperTerm extends Component {
   }
 
   increaseFontSize () {
-    this.changeFontSize(1, true);
+    this.changeFontSize(1, { relative: true });
   }
 
   decreaseFontSize () {
-    this.changeFontSize(-1, true);
+    this.changeFontSize(-1, { relative: true });
   }
 
   onSessionExit ({ uid }) {
@@ -455,6 +455,7 @@ export default class HyperTerm extends Component {
   componentWillUnmount () {
     this.rpc.destroy();
     clearTimeout(this.resizeIndicatorTimeout);
+    clearTimeout(this.fontSizeIndicatorTimeout);
     if (this.keys) this.keys.reset();
     delete this.clicks;
     clearTimeout(this.clickTimer);

--- a/app/hyperterm.js
+++ b/app/hyperterm.js
@@ -273,12 +273,12 @@ export default class HyperTerm extends Component {
   }
 
   changeFontSize (value) {
-    this.setState({fontSize: this.state.fontSize + value});
+    this.setState({ fontSize: this.state.fontSize + value });
   }
 
   resetFontSize () {
     // TODO: once we have preferences, we need to read from it
-    this.setState({fontSize: 12});
+    this.setState({ fontSize: 12 });
   }
 
   increaseFontSize () {

--- a/app/hyperterm.js
+++ b/app/hyperterm.js
@@ -23,7 +23,8 @@ export default class HyperTerm extends Component {
       mac: /Mac/.test(navigator.userAgent),
       resizeIndicatorShowing: false,
       updateVersion: null,
-      updateNote: null
+      updateNote: null,
+      fontSize: 12
     };
 
     // we set this to true when the first tab
@@ -77,6 +78,7 @@ export default class HyperTerm extends Component {
                   ref={`term-${uid}`}
                   cols={this.state.cols}
                   rows={this.state.rows}
+                  fontSize={this.state.fontSize}
                   url={this.state.urls[uid]}
                   onResize={this.onResize}
                   onTitle={this.setTitle.bind(this, uid)}
@@ -89,7 +91,8 @@ export default class HyperTerm extends Component {
         }</div>
       </div>
       <div className={classes('resize-indicator', { showing: this.state.resizeIndicatorShowing })}>
-        { this.state.cols }x{ this.state.rows }
+        <div>{ this.state.fontSize }px</div>
+        <div>{ this.state.cols }x{ this.state.rows }</div>
       </div>
       <div className={classes('update-indicator', { showing: null !== this.state.updateVersion })}>
         Update available (<b>{ this.state.updateVersion }</b>).
@@ -270,21 +273,12 @@ export default class HyperTerm extends Component {
   }
 
   changeFontSize (value) {
-    const uid = this.state.sessions[this.state.active];
-    const term = this.refs[`term-${uid}`];
-    if (term) {
-      const size = term.term.prefs_.get('font-size');
-      term.term.prefs_.set('font-size', size + value);
-    }
+    this.setState({fontSize: this.state.fontSize + value});
   }
 
   resetFontSize () {
-    const uid = this.state.sessions[this.state.active];
-    const term = this.refs[`term-${uid}`];
-    if (term) {
-      // TODO: once we have preferences, we need to read from it
-      term.term.prefs_.set('font-size', 12);
-    }
+    // TODO: once we have preferences, we need to read from it
+    this.setState({fontSize: 12});
   }
 
   increaseFontSize () {
@@ -373,8 +367,8 @@ export default class HyperTerm extends Component {
       keys.bind('command+shift+]', this.moveRight);
       keys.bind('command+alt+left', this.moveLeft);
       keys.bind('command+alt+right', this.moveRight);
-      keys.bind('command+=', this.increaseFontSize);
-      keys.bind('command+-', this.decreaseFontSize);
+      keys.bind('command+plus', this.increaseFontSize);
+      keys.bind('command+minus', this.decreaseFontSize);
       keys.bind('command+0', this.resetFontSize);
 
       this.keys = keys;

--- a/app/term.js
+++ b/app/term.js
@@ -62,7 +62,7 @@ export default class Term extends Component {
     }
 
     this.term.prefs_.set('font-family', "Menlo, 'DejaVu Sans Mono', 'Lucida Console', monospace");
-    this.term.prefs_.set('font-size', 11);
+    this.term.prefs_.set('font-size', this.props.fontSize);
     this.term.prefs_.set('cursor-color', '#F81CE5');
     this.term.prefs_.set('enable-clipboard-notice', false);
     this.term.prefs_.set('background-color', '#000');
@@ -88,6 +88,12 @@ export default class Term extends Component {
 
   getTermDocument () {
     return this.term.document_;
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (this.props.fontSize !== nextProps.fontSize) {
+      this.term.prefs_.set('font-size', nextProps.fontSize);
+    }
   }
 
   shouldComponentUpdate (nextProps) {


### PR DESCRIPTION
closes #44 and #45 

- fixed keyboard shortcut registering (listeners were being called twice)
- now saving fontSize in the state of Hyperterm
- Term now accepts fontSize as a prop and internally sets it
- added font size indicator on change (next to rows x cols)

(bonus improvement: now font size is shared between all tabs)