### PR TITLE
Get rid of border-radius in fullscreen mode (macOS) fixes #21

### DIFF
--- a/app/css/hyperterm.css
+++ b/app/css/hyperterm.css
@@ -7,10 +7,6 @@
   border: 1px solid #333;
 }
 
-.mac.main {
-  border-radius: 5px;
-}
-
 header {
   position: fixed;
   top: 1px;


### PR DESCRIPTION
Tried this with and without the border, and it looks better with a border.

![screen shot 2016-07-06 at 6 37 16 pm](https://cloud.githubusercontent.com/assets/1388079/16652944/6a2382c4-4413-11e6-8789-c685800285bf.png)
