### PR TITLE
Add configurable styling for resize indicators

### DIFF
--- a/app/css/hyperterm.css
+++ b/app/css/hyperterm.css
@@ -103,3 +103,5 @@ header {
   width: 1em;
   height: 1em;
 }
+
+.dn { display: none; }

--- a/app/hyperterm.js
+++ b/app/hyperterm.js
@@ -74,7 +74,8 @@ export default class HyperTerm extends Component {
   }
 
   render () {
-    const { backgroundColor, borderColor, css } = this.props.config;
+    const { backgroundColor, borderColor, css, resizeIndicator } = this.props.config;
+
     return <div onClick={ this.focusActive }>
       <div style={{ borderColor }} className={ classes('main', { mac: this.state.mac }) }>
         <header style={{ backgroundColor }} onMouseDown={this.onHeaderMouseDown}>
@@ -122,8 +123,10 @@ export default class HyperTerm extends Component {
         }</div>
       </div>
       <div className={classes('resize-indicator', { showing: this.state.resizeIndicatorShowing })}>
-        {this.state.fontSizeIndicatorShowing && <div>{ this.state.fontSize }px</div>}
-        <div>{ this.state.cols }x{ this.state.rows }</div>
+        <div className={classes({ dn: !this.state.fontSizeIndicatorShowing })} style={resizeIndicator}>
+          { this.state.fontSize }px
+        </div>
+        <div style={resizeIndicator}>{ this.state.cols }x{ this.state.rows }</div>
       </div>
       <div className={classes('update-indicator', { showing: null !== this.state.updateVersion && !this.state.dismissedUpdate })}>
         Version <b>{ this.state.updateVersion }</b> ready.

--- a/config-default.js
+++ b/config-default.js
@@ -15,6 +15,9 @@ module.exports = {
     // border color (winodw, tabs)
     borderColor: '#333',
 
+    // style resize-indicators
+    resizeIndicator: {},
+
     // custom css to embed in the main window
     css: [''],
 


### PR DESCRIPTION
This provides the ability to configure the
styling of resize indicator through the
.hyperterm.js file.

Currently the `resizeIndicator` object
is passed to the div, perhaps we might
only want to allow a green list of properties?

Somewhat related to #45