### PR TITLE
Add missing shebang to scripts/install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Electron's version.
 export npm_config_target=1.2.3
 # The architecture of Electron, can be ia32 or x64.


### PR DESCRIPTION
Fix the error while executing in some none-bash shell(eg. fish):

```
  Failed to execute process './scripts/install.sh'. Reason:
  exec: Exec format error
  The file './scripts/install.sh' is marked as an executable but could not be run by the operating system.
```