### PR TITLE
Fix two comments in default config file

### DIFF
--- a/config-default.js
+++ b/config-default.js
@@ -21,10 +21,10 @@ module.exports = {
     // custom css to embed in the main window
     css: '',
 
-    // custom padding (css format, i.e.: `top right bottom left`)
+    // custom css to embed in the terminal window
     termCSS: '',
 
-    // custom padding
+    // custom padding (css format, i.e.: `top right bottom left`)
     padding: '12px 14px',
 
     // some color overrides. see http://bit.ly/29k1iU2 for


### PR DESCRIPTION
The comments of termCSS and padding attributes in default config file had some problems, I think the comment of termCSS attribute was replaced by padding attribute's comment. I have fixed them, a super minor change.