### PR TITLE
Make "Open Preference" compatible with none-bash shell. Fix #143

### DIFF
--- a/app/lib/actions/ui.js
+++ b/app/lib/actions/ui.js
@@ -129,9 +129,9 @@ export function showPreferences () {
           rpc.once('session data', () => {
             dispatch(sendSessionData(
               uid,
-              ['# Attempting to open ~/.hyperterm.js with your $EDITOR',
+              ['# Attempting to open ~/.hyperterm.js with your editor',
                '# If this doesn\'t work, open it manually with your favorite editor!',
-               '$EDITOR ~/.hyperterm.js && exit',
+               'bash -ic \'${EDITOR:-vi} ~/.hyperterm.js\'',
                ''
               ].join('\n')
             ));

--- a/app/lib/actions/ui.js
+++ b/app/lib/actions/ui.js
@@ -129,8 +129,8 @@ export function showPreferences () {
           rpc.once('session data', () => {
             dispatch(sendSessionData(
               uid,
-              ['# Attempting to open ~/.hyperterm.js with your editor',
-               '# If this doesn\'t work, open it manually with your favorite editor!',
+              ['echo \'Attempting to open ~/.hyperterm.js with your editor\'',
+               'echo \'If this doesn\\\'t work, open it manually with your favorite editor!\'',
                'bash -ic \'${EDITOR:-vi} ~/.hyperterm.js\'',
                ''
               ].join('\n')


### PR DESCRIPTION
Note: the tab no longer auto closed.
But I think it's an acceptable approach, still better than throwing error :P 