### PR TITLE
Change plugins "reload notification" description

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -93,7 +93,7 @@ function updatePlugins ({ force = false } = {}) {
         if (changed) {
           notify(
             'Plugins Updated',
-            'Restart the app or hot-reload with "Plugins" > "Reload Now" to enjoy the updates!'
+            'Restart the app or hot-reload with "Plugins" > "Update All Now" to enjoy the updates!'
           );
         } else {
           notify(


### PR DESCRIPTION
There is no "Reload Now" menu item. Changed to the "Update All Now"
<img width="178" alt="fullscreen_16_07_16_11_55" src="https://cloud.githubusercontent.com/assets/867546/16893828/72bf364a-4b4c-11e6-8450-8b2400ee8fb5.png">