### PR TITLE
change the version of eslint-config-standard from 5.3.1 to 5.3.5

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,7 +29,7 @@
     "babel-preset-es2015-native-modules": "6.6.0",
     "babel-preset-react": "6.11.1",
     "eslint": "3.0.1",
-    "eslint-config-standard": "5.3.1",
+    "eslint-config-standard": "5.3.5",
     "eslint-plugin-promise": "1.3.2",
     "eslint-plugin-react": "5.2.2",
     "eslint-plugin-standard": "1.3.2",


### PR DESCRIPTION
the previous dependencies between eslint and eslint-config-standard
return the following warn and error.

```bash
npm WARN peerDependencies The peer dependency eslint@^2.0.0-rc.0
included from eslint-config-standard will no
npm WARN peerDependencies longer be automatically installed to fulfill
the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to
depend on it explicitly.
```
```bash
npm ERR! peerinvalid The package eslint@3.0.1 does not satisfy its
siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-config-standard@5.3.1 wants
eslint@^2.0.0-rc.0
```
so updated the version of eslint-config-standard from 5.3.1 to 5.3.5
which is the newest now.