### PR TITLE
feature: prevent dropped files, use path

### DIFF
--- a/app/lib/components/term.js
+++ b/app/lib/components/term.js
@@ -1,6 +1,7 @@
 /* global Blob,URL,requestAnimationFrame */
 import React from 'react';
 import hterm from '../hterm';
+import rpc from '../rpc';
 import Component from '../component';
 
 export default class Term extends Component {
@@ -12,6 +13,10 @@ export default class Term extends Component {
     this.onScrollEnter = this.onScrollEnter.bind(this);
     this.onScrollLeave = this.onScrollLeave.bind(this);
     props.ref_(this);
+    // catches dropped files from the Main thread in order to print path
+    rpc.on('dropped-file', (url) => {
+      this.write(url);
+    });
   }
 
   componentDidMount () {

--- a/index.js
+++ b/index.js
@@ -55,6 +55,15 @@ app.on('ready', () => {
     });
     winCount++;
     win.loadURL(url);
+    // prevent file drops to navigate the window. Instead handle explicitly
+    // file drops as string to location of file.
+    win.webContents.on('will-navigate', (event, url) => {
+      event.preventDefault();
+      const path = url.split('file://'); // if has file:// prefix...
+      // ...send chopped url. The fallback is meant as contigency, for
+      // edge cases the author couldn't anticipate. Remove if needed.
+      rpc.emit('dropped-file', path.length > 1 ? path[1] : path[0]);
+    });
 
     const rpc = createRPC(win);
     const sessions = new Map();


### PR DESCRIPTION
When file is dragged into context, do not navigate to file (which could be regarded a bug, as is) instead use path to file in current line (as feature)

Fixes: https://github.com/zeit/hyperterm/issues/110
Make use of https://github.com/electron/electron/pull/931