### PR TITLE
Provide hooks to open a new tab to the same directory

### DIFF
--- a/app/lib/actions/sessions.js
+++ b/app/lib/actions/sessions.js
@@ -40,12 +40,11 @@ export function addSession (uid, shell) {
 export function requestSession (uid) {
   return (dispatch, getState) => {
     const { ui } = getState();
-    const cols = ui.cols;
-    const rows = ui.rows;
+    const { cols, rows, cwd } = ui;
     dispatch({
       type: SESSION_REQUEST,
       effect: () => {
-        rpc.emit('new', { cols, rows });
+        rpc.emit('new', { cols, rows, cwd });
       }
     });
   };

--- a/app/lib/actions/sessions.js
+++ b/app/lib/actions/sessions.js
@@ -19,7 +19,7 @@ import {
   SESSION_SET_PROCESS_TITLE
 } from '../constants/sessions';
 
-export function addSession (uid, shell) {
+export function addSession (uid, shell, pid) {
   return (dispatch, getState) => {
     const { sessions } = getState();
 
@@ -32,7 +32,8 @@ export function addSession (uid, shell) {
     dispatch({
       type: SESSION_ADD,
       uid,
-      shell
+      shell,
+      pid
     });
   };
 }

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -43,8 +43,8 @@ rpc.on('ready', () => {
   store_.dispatch(init());
 });
 
-rpc.on('session add', ({ uid, shell }) => {
-  store_.dispatch(sessionActions.addSession(uid, shell));
+rpc.on('session add', ({ uid, shell, pid }) => {
+  store_.dispatch(sessionActions.addSession(uid, shell, pid));
 });
 
 rpc.on('session data', ({ uid, data }) => {

--- a/app/lib/reducers/sessions.js
+++ b/app/lib/reducers/sessions.js
@@ -26,7 +26,8 @@ function Session (obj) {
     write: null,
     url: null,
     cleared: false,
-    shell: ''
+    shell: '',
+    pid: null
   }).merge(obj);
 }
 
@@ -42,7 +43,8 @@ const reducer = (state = initialState, action) => {
     case SESSION_ADD:
       return state.setIn(['sessions', action.uid], Session({
         uid: action.uid,
-        shell: action.shell.split('/').pop()
+        shell: action.shell.split('/').pop(),
+        pid: action.pid
       }));
 
     case SESSION_URL_SET:

--- a/index.js
+++ b/index.js
@@ -85,7 +85,8 @@ app.on('ready', () => {
         sessions.set(uid, session);
         rpc.emit('session add', {
           uid,
-          shell: session.shell
+          shell: session.shell,
+          pid: session.pty.pid
         });
 
         session.on('data', (data) => {

--- a/index.js
+++ b/index.js
@@ -80,8 +80,8 @@ app.on('ready', () => {
       }
     });
 
-    rpc.on('new', ({ rows = 40, cols = 100 }) => {
-      initSession({ rows, cols }, (uid, session) => {
+    rpc.on('new', ({ rows = 40, cols = 100, cwd = process.env.HOME }) => {
+      initSession({ rows, cols, cwd }, (uid, session) => {
         sessions.set(uid, session);
         rpc.emit('session add', {
           uid,

--- a/session.js
+++ b/session.js
@@ -18,12 +18,12 @@ const TITLE_POLL_INTERVAL = 500;
 
 module.exports = class Session extends EventEmitter {
 
-  constructor ({ rows, cols: columns }) {
+  constructor ({ rows, cols: columns, cwd }) {
     super();
     this.pty = spawn(defaultShell, ['--login'], {
       columns,
       rows,
-      cwd: process.env.HOME,
+      cwd,
       env: Object.assign({}, process.env, {
         TERM: 'xterm-256color'
       })


### PR DESCRIPTION
- Allows `cwd` parameter to be changed when creating a new directory
- Exposes the `pid` of the newly created session in the dispatch event

The plugin to try this out is called [hypercwd](https://github.com/hharnisc/hypercwd) it's published to NPM under the name `hypercwd`

This is related to #4 