### PR TITLE
Fix onWindow hook

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -266,10 +266,10 @@ exports.onApp = function (app) {
   });
 };
 
-exports.onWindow = function (win, app) {
+exports.onWindow = function (win) {
   modules.forEach((plugin) => {
     if (plugin.onWindow) {
-      plugin.onWindow(app);
+      plugin.onWindow(win);
     }
   });
 };


### PR DESCRIPTION
The `onWindow` method of plugins.js has no second parameter of `app`.
Switch to the `BrowserWindow` passed as the first parameter.