### PR TITLE
fix plugins.onWindows()

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -266,10 +266,10 @@ exports.onApp = function (app) {
   });
 };
 
-exports.onWindow = function (win, app) {
+exports.onWindow = function (win) {
   modules.forEach((plugin) => {
     if (plugin.onWindow) {
-      plugin.onWindow(app);
+      plugin.onWindow(win);
     }
   });
 };


### PR DESCRIPTION
Trying to write a plugin, I noticed `plugin.onWindow()` will never receive a window instance. `plugins.onWindows(win, app)` passes along `app` instead of `win`.