### PR TITLE
Example React Native implementation of hyperterm header

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ modules are built with `electron`, run:
 $ ./scripts/install.sh
 ```
 
-Then, you want to make sure `app/dist` is populated. I recommend
-running `webpack` with `--watch` so that any changes you make
-to the app are detected.
+Then, you want to make sure `app/dist` is populated.
 
 ```bash
 $ cd app/

--- a/app/lib/components/header.js
+++ b/app/lib/components/header.js
@@ -1,16 +1,20 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import Tabs_ from './tabs';
-import Component from '../component';
 import { decorate, getTabsProps } from '../utils/plugins';
+import { StyleSheet, View } from 'react-native';
+import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 const Tabs = decorate(Tabs_, 'Tabs');
 
 export default class Header extends Component {
-
   constructor () {
     super();
     this.onChangeIntent = this.onChangeIntent.bind(this);
     this.onHeaderMouseDown = this.onHeaderMouseDown.bind(this);
+  }
+
+  shouldComponentUpdate (...args) {
+    return shouldComponentUpdate.apply(this, [args])
   }
 
   onChangeIntent (active) {
@@ -32,9 +36,9 @@ export default class Header extends Component {
 
     if (this.clicks++ >= 2) {
       if (this.maximized) {
-        this.rpc.emit('unmaximize');
+        window.rpc.emit('unmaximize');
       } else {
-        this.rpc.emit('maximize');
+        window.rpc.emit('maximize');
       }
       this.clicks = 0;
       this.maximized = !this.maximized;
@@ -52,40 +56,62 @@ export default class Header extends Component {
     clearTimeout(this.clickTimer);
   }
 
-  template (css) {
-    const { isMac, backgroundColor } = this.props;
-    const props = getTabsProps(this.props, {
-      tabs: this.props.tabs,
-      borderColor: this.props.borderColor,
-      onClose: this.props.onCloseTab,
-      onChange: this.onChangeIntent
+  render () {
+    const {
+      backgroundColor,
+      borderColor,
+      customChildren,
+      customChildrenBefore,
+      isMac,
+      onCloseTab,
+      tabs
+    } = this.props;
+
+    const tabProps = getTabsProps(this.props, {
+      borderColor,
+      onChange: this.onChangeIntent,
+      onClose: onCloseTab,
+      tabs
     });
-    return <header
-      style={{ backgroundColor }}
-      className={ css('header', isMac && 'headerRounded') }
-      onMouseDown={ this.onHeaderMouseDown }>
-        { this.props.customChildrenBefore }
-        <Tabs {...props} />
-        { this.props.customChildren }
-    </header>;
+
+    return (
+      <View
+        accessibilityRole='header'
+        onMouseDown={ this.onHeaderMouseDown }
+        style={[
+          { backgroundColor },
+          styles.header,
+          isMac && styles.headerRounded
+        ]}>
+          { customChildrenBefore }
+          <Tabs {...tabProps} />
+          { customChildren }
+      </View>
+    );
   }
-
-  styles () {
-    return {
-      header: {
-        position: 'fixed',
-        top: '1px',
-        left: '1px',
-        right: '1px',
-        background: '#000',
-        zIndex: '100'
-      },
-
-      headerRounded: {
-        borderTopLeftRadius: '6px',
-        borderTopRightRadius: '6px'
-      }
-    };
-  }
-
 }
+
+Header.propTypes = {
+  borderColor: PropTypes.string,
+  customChildrenBefore: PropTypes.any,
+  customChildren: PropTypes.any,
+  isMac: PropTypes.bool,
+  onChangeTab: PropTypes.func,
+  onCloseTab: PropTypes.func,
+  tabs: PropTypes.array
+};
+
+const styles = StyleSheet.create({
+  header: {
+    position: 'fixed',
+    top: '1px',
+    left: '1px',
+    right: '1px',
+    backgroundColor: '#000',
+    zIndex: 100
+  },
+  headerRounded: {
+    borderTopLeftRadius: '6px',
+    borderTopRightRadius: '6px'
+  }
+});

--- a/app/lib/components/tab.js
+++ b/app/lib/components/tab.js
@@ -1,14 +1,19 @@
-import React from 'react';
-import Component from '../component';
+import React, { Component, PropTypes } from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 export default class Tab extends Component {
-  constructor () {
-    super();
+  constructor (props) {
+    super(props);
     this.hover = this.hover.bind(this);
     this.blur = this.blur.bind(this);
     this.state = {
       hovered: false
     };
+  }
+
+  shouldComponentUpdate (...args) {
+    return shouldComponentUpdate.apply(this, [args])
   }
 
   hover () {
@@ -19,156 +24,127 @@ export default class Tab extends Component {
     this.setState({ hovered: false });
   }
 
-  template (css) {
+  render () {
     const { isActive, isFirst, isLast, borderColor, hasActivity } = this.props;
     const { hovered } = this.state;
 
-    return <li
+    return <View
+      accessibilityRole='button'
       onMouseEnter={ this.hover }
       onMouseLeave={ this.blur }
       onClick={ this.props.onClick }
-      style={{ borderColor }}
-      className={ css(
-        'tab',
-        isFirst && 'first',
-        isActive && 'active',
-        hasActivity && 'hasActivity'
-      ) }>
+      style={[
+        { borderColor },
+        styles.tab,
+        isFirst && styles.first,
+        hasActivity && styles.hasActivity
+      ]}>
+        {isActive ? <View style={styles.tabBorder} /> : null}
         { this.props.customChildrenBefore }
-        <span
-          className={ css(
-            'text',
-            isLast && 'textLast',
-            isActive && 'textActive'
-          ) }
-          onClick={ this.props.isActive ? null : this.props.onSelect }>
-          <span className={ css('textInner') }>
+        <View
+          style={[
+            styles.textBox,
+            isLast && styles.textBoxLast,
+            (isActive || hovered) && styles.textBoxActive
+          ]}
+          onClick={ isActive ? null : this.props.onSelect }>
+          <Text style={[
+            styles.text,
+            isActive && styles.textActive,
+          ]}>
             { this.props.text }
-          </span>
-        </span>
-        <i
-          className={ css(
-            'icon',
-            hovered && 'iconHovered'
-          ) }
+          </Text>
+        </View>
+        <View
+          pointerEvents={ hovered ? 'auto' : 'none' }
+          style={[
+            styles.icon,
+            hovered && styles.iconHovered
+          ]}
           onClick={ this.props.onClose }>
-          <svg className={ css('shape') }>
+          <svg style={svgStyles}>
             <use xlinkHref='assets/icons.svg#close'></use>
           </svg>
-        </i>
+        </View>
         { this.props.customChildren }
-    </li>;
+    </View>;
   }
-
-  styles () {
-    return {
-      tab: {
-        color: '#ccc',
-        listStyleType: 'none',
-        flexGrow: 1,
-        position: 'relative',
-        ':hover': {
-          color: '#ccc'
-        }
-      },
-
-      first: {
-        marginLeft: '76px'
-      },
-
-      active: {
-        color: '#fff',
-        ':before': {
-          position: 'absolute',
-          content: '" "',
-          borderBottom: '1px solid #000',
-          display: 'block',
-          left: '0px',
-          right: '0px',
-          bottom: '-1px'
-        },
-        ':hover': {
-          color: '#fff'
-        }
-      },
-
-      hasActivity: {
-        color: '#50E3C2',
-        ':hover': {
-          color: '#50E3C2'
-        }
-      },
-
-      text: {
-        transition: 'color .2s ease',
-        height: '34px',
-        display: 'block',
-        width: '100%',
-        position: 'relative',
-        borderLeft: '1px solid transparent',
-        borderRight: '1px solid transparent',
-        overflow: 'hidden'
-      },
-
-      textInner: {
-        position: 'absolute',
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        textAlign: 'center'
-      },
-
-      textLast: {
-        borderRightWidth: 0
-      },
-
-      textActive: {
-        borderColor: 'inherit'
-      },
-
-      icon: {
-        transition: `opacity .2s ease, color .2s ease,
-          transform .25s ease, background-color .1s ease`,
-        pointerEvents: 'none',
-        position: 'absolute',
-        right: '7px',
-        top: '10px',
-        display: 'inline-block',
-        width: '14px',
-        height: '14px',
-        borderRadius: '100%',
-        color: '#e9e9e9',
-        opacity: 0,
-        transform: 'scale(.95)',
-
-        ':hover': {
-          backgroundColor: 'rgba(255,255,255, .13)',
-          color: '#fff'
-        },
-
-        ':active': {
-          backgroundColor: 'rgba(255,255,255, .1)',
-          color: '#909090'
-        }
-      },
-
-      iconHovered: {
-        opacity: 1,
-        transform: 'none',
-        pointerEvents: 'all'
-      },
-
-      shape: {
-        position: 'absolute',
-        left: '4px',
-        top: '4px',
-        width: '6px',
-        height: '6px',
-        verticalAlign: 'middle',
-        fill: 'currentColor'
-      }
-    };
-  }
-
 }
+
+const svgStyles = {
+  position: 'absolute',
+  left: '4px',
+  top: '4px',
+  width: '6px',
+  height: '6px',
+  textAlignVertical: 'center',
+  fill: 'currentColor'
+}
+
+const styles = StyleSheet.create({
+  tab: {
+    flex: 1,
+    outline: 'none'
+  },
+  first: {
+    marginLeft: '76px'
+  },
+  tabBorder: {
+    position: 'absolute',
+    height: 1,
+    backgroundColor: '#000',
+    left: '0px',
+    right: '0px',
+    bottom: '-1px'
+  },
+  hasActivity: {
+    color: '#50E3C2',
+  },
+  textBox: {
+    transition: 'color .2s ease',
+    height: '34px',
+    width: '100%',
+    borderRightWidth: 1,
+    borderLeftWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'transparent',
+    overflow: 'hidden',
+    justifyContent: 'center',
+  },
+  textBoxLast: {
+    borderRightWidth: 0
+  },
+  textBoxActive: {
+    borderColor: 'inherit'
+  },
+  text: {
+    fontSize: '12px',
+    fontFamily: `-apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif`,
+    color: '#ccc',
+    textAlign: 'center'
+  },
+  textActive: {
+    color: '#fff'
+  },
+  icon: {
+    transition: `opacity .2s ease, color .2s ease,
+      transform .25s ease, background-color .1s ease`,
+    position: 'absolute',
+    right: '7px',
+    top: '10px',
+    display: 'inline-block',
+    width: '14px',
+    height: '14px',
+    borderRadius: '100%',
+    color: '#e9e9e9',
+    opacity: 0,
+    transform: [ { scale: 0.95 } ],
+  },
+  iconHovered: {
+    opacity: 1,
+    transform: []
+  }
+})

--- a/app/lib/components/tabs.js
+++ b/app/lib/components/tabs.js
@@ -1,13 +1,17 @@
 import Tab_ from './tab';
-import React from 'react';
-import Component from '../component';
+import React, { Component, PropTypes } from 'react';
 import { decorate, getTabProps } from '../utils/plugins';
+import { StyleSheet, View, Text } from 'react-native';
+import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 const Tab = decorate(Tab_, 'Tab');
 
 export default class Tabs extends Component {
+  shouldComponentUpdate (...args) {
+    return shouldComponentUpdate.apply(this, [args])
+  }
 
-  template (css) {
+  render () {
     const {
       tabs = [],
       borderColor,
@@ -15,18 +19,16 @@ export default class Tabs extends Component {
       onClose
     } = this.props;
 
-    return <nav className={ css('nav') }>
+    return <View accessibilityRole='nav' style={styles.nav}>
       {
         tabs.length
           ? 1 === tabs.length
-            ? <div className={ css('title') }>{ tabs[0].title }</div>
-            : <ul
-                style={{ borderColor }}
-                className={ css('list') }>
+            ? <Text style={styles.title}>{ tabs[0].title }</Text>
+            : <View style={[ styles.list, { borderColor }]}>
                 {
                   tabs.map((tab, i) => {
                     const { uid, title, isActive, hasActivity } = tab;
-                    const props = getTabProps(tab, this.props, {
+                    const tabProps = getTabProps(tab, this.props, {
                       text: '' === title ? 'Shell' : title,
                       isFirst: 0 === i,
                       isLast: tabs.length - 1 === i,
@@ -36,45 +38,49 @@ export default class Tabs extends Component {
                       onSelect: onChange.bind(null, uid),
                       onClose: onClose.bind(null, uid)
                     });
-                    return <Tab key={`tab-${uid}`} {...props} />;
+                    return <Tab key={`tab-${uid}`} {...tabProps} />;
                   })
                 }
-              </ul>
+              </View>
           : null
       }
       { this.props.customChildren }
-    </nav>;
+    </View>;
   }
-
-  styles () {
-    return {
-      nav: {
-        fontSize: '12px',
-        fontFamily: `-apple-system, BlinkMacSystemFont,
-        "Segoe UI", "Roboto", "Oxygen",
-        "Ubuntu", "Cantarell", "Fira Sans",
-        "Droid Sans", "Helvetica Neue", sans-serif`,
-        height: '34px',
-        lineHeight: '34px',
-        verticalAlign: 'middle',
-        color: '#9B9B9B',
-        cursor: 'default',
-        WebkitUserSelect: 'none',
-        WebkitAppRegion: 'drag'
-      },
-
-      title: {
-        textAlign: 'center',
-        color: '#fff'
-      },
-
-      list: {
-        borderBottom: '1px solid #333',
-        maxHeight: '34px',
-        display: 'flex',
-        flexFlow: 'row'
-      }
-    };
-  }
-
 }
+
+Tabs.propTypes = {
+  borderColor: PropTypes.string,
+  onChange: PropTypes.func,
+  onClose: PropTypes.func,
+  tabs: PropTypes.array,
+};
+
+const styles = StyleSheet.create({
+  nav: {
+    height: '34px',
+    justifyContent: 'center',
+    cursor: 'default',
+    userSelect: 'none',
+    WebkitAppRegion: 'drag'
+  },
+
+  title: {
+    fontSize: '12px',
+    fontFamily: `-apple-system, BlinkMacSystemFont,
+      "Segoe UI", "Roboto", "Oxygen",
+      "Ubuntu", "Cantarell", "Fira Sans",
+      "Droid Sans", "Helvetica Neue", sans-serif`,
+    textAlign: 'center',
+    color: '#fff'
+  },
+
+  list: {
+    borderBottomWidth: 1,
+    borderBottomStyle: 'solid',
+    borderBottomColor: '#333',
+    maxHeight: '34px',
+    flexDirection: 'row',
+    flexWrap: 'nowrap'
+  }
+});

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "react-addons-pure-render-mixin": "15.2.1",
     "react-deep-force-update": "2.0.1",
     "react-dom": "15.2.1",
+    "react-native-web": "0.0.38",
     "react-redux": "4.4.5",
     "redux": "3.5.2",
     "redux-thunk": "2.1.0",

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -49,5 +49,10 @@ module.exports = {
         'NODE_ENV': JSON.stringify(nodeEnv)
       }
     })
-  ]
+  ],
+  resolve: {
+    alias: {
+      'react-native': 'react-native-web'
+    }
+  }
 };


### PR DESCRIPTION
Hey,

Here's a rough example of how you could use React Native to build the terminal's header. There are a few warnings in the console about style properties React Native doesn't currently know about.

You'll notice that CSS pseudo-classes (e.g. `:hover`) aren't supported. However, it's quite common to track state like hover in JavaScript anyway (as you do in `Tab`).

Something else worth mentioning is that `View` is the main building block and has a column-based flexbox layout by default. It won't accept any text or font styles; those have to be applied to a `Text` element. A helpful pattern is to create a component that encapsulates the typography concerns, e.g., `<AppText color='white' size='normal'>bash</AppText>`.

User theming could be done with JS objects. Since you'd be working with objects and not strings, you can better control exactly what custom styles you apply to the components. For example, the color but not position of text nodes could be customizable:

```
exports.decorateConfig = (config) => {
  return Object.assign({}, config, {
    borderColor: 'yellow',
    cursorColor: 'yellow',
    css: Object.assign({}, config.css, {
      tabText: {
        color: 'yellow', // this style is a valid override
        position: 'fixed' // this style is not, and you ignore it
      },
      tabsTitle: {
        color: 'yellow'
      }
    })
  });
}
```

