### PR TITLE
Add an option for a non-login shell to be run

### DIFF
--- a/config-default.js
+++ b/config-default.js
@@ -46,7 +46,11 @@ module.exports = {
       '#cc00ff',
       '#00ffff',
       '#ffffff'
-    ]
+    ],
+
+    // the shell to run when spawning a new session (i.e. /usr/local/bin/fish)
+    // if empty, your login shell will be used by default
+    shell: '/bin/bash'
   },
 
   // a list of plugins to fetch and install from npm

--- a/config-default.js
+++ b/config-default.js
@@ -49,8 +49,8 @@ module.exports = {
     ],
 
     // the shell to run when spawning a new session (i.e. /usr/local/bin/fish)
-    // if empty, your login shell will be used by default
-    shell: '/bin/bash'
+    // if left empty, your system's login shell will be used by default
+    shell: ''
   },
 
   // a list of plugins to fetch and install from npm

--- a/index.js
+++ b/index.js
@@ -82,7 +82,9 @@ app.on('ready', () => {
     });
 
     rpc.on('new', ({ rows = 40, cols = 100, cwd = process.env.HOME }) => {
-      initSession({ rows, cols, cwd }, (uid, session) => {
+      const shell = cfg.shell;
+
+      initSession({ rows, cols, cwd, shell }, (uid, session) => {
         sessions.set(uid, session);
         rpc.emit('session add', {
           uid,

--- a/session.js
+++ b/session.js
@@ -18,9 +18,9 @@ const TITLE_POLL_INTERVAL = 500;
 
 module.exports = class Session extends EventEmitter {
 
-  constructor ({ rows, cols: columns, cwd }) {
+  constructor ({ rows, cols: columns, cwd, shell }) {
     super();
-    this.pty = spawn(defaultShell, ['--login'], {
+    this.pty = spawn(shell || defaultShell, ['--login'], {
       columns,
       rows,
       cwd,


### PR DESCRIPTION
This adds a new key to the config object, called `shell`. This allows the user to specify a custom shell when running hyperterm. By default, however, the user's login shell will be used

Solves #81 