### PR TITLE
make update feed not only OS X

### DIFF
--- a/auto-updater.js
+++ b/auto-updater.js
@@ -3,7 +3,7 @@ const { version } = require('./package');
 const notify = require('./notify');
 const ms = require('ms');
 
-const FEED_URL = 'https://hyperterm-updates.now.sh/update/osx';
+const FEED_URL = process.platform === 'darwin' ? 'https://hyperterm-updates.now.sh/update/osx' : '';
 let isInit = false;
 
 function init () {


### PR DESCRIPTION
I'm not sure what the url for others is, since I'm not fully sure if it already exists for other platforms.