### PR TITLE
Config option to silence bell

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -54,7 +54,10 @@ module.exports = {
 
     // the shell to run when spawning a new session (i.e. /usr/local/bin/fish)
     // if left empty, your system's login shell will be used by default
-    shell: ''
+    shell: '',
+
+    // enable bell ring
+    enableBell: true,
 
     // for advanced config flags please refer to https://hyperterm.org/#cfg
   },

--- a/app/lib/utils/override-event.js
+++ b/app/lib/utils/override-event.js
@@ -1,0 +1,17 @@
+const config = require('./config');
+
+let enableBell = config.getConfig().enableBell;
+
+config.subscribe(() => {
+  // listen on confg update to enable/disable bell
+  enableBell = config.getConfig().enableBell;
+});
+
+export default function shouldIgnoreEvent (data) {
+  switch(data) {
+    case '\u0007':
+        return !enableBell;
+  }
+
+  return false;
+}

--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -1,5 +1,6 @@
 import rpc from '../rpc';
 import getURL from '../utils/url-command';
+import shouldIgnoreEvent from '../utils/override-event';
 import { keys } from '../utils/object';
 import {
   SESSION_ADD,
@@ -57,6 +58,8 @@ export function addSessionData (uid, data) {
       type: SESSION_ADD_DATA,
       data,
       effect () {
+        if (shouldIgnoreEvent(data)) 
+          return;
         const { shell } = getState().sessions.sessions[uid];
 
         const enterKey = Boolean(data.match(/\n/));


### PR DESCRIPTION
Add a config option `audibleBell` and handlers to silence the bell by muting hterm's bell audio. This is achieved by toggling `this.term.bellAudio_.muted` in app/lib/components/term.js. 

We leave the bell on by default so users with out of date config files will not wonder where their bell audio went. 

Closes issue #125 