### PR TITLE
Dynamically change the `font-smoothing` pref

### DIFF
--- a/app/lib/actions/ui.js
+++ b/app/lib/actions/ui.js
@@ -15,7 +15,8 @@ import {
   UI_MOVE_LEFT,
   UI_MOVE_RIGHT,
   UI_MOVE_TO,
-  UI_SHOW_PREFERENCES
+  UI_SHOW_PREFERENCES,
+  UI_WINDOW_MOVE
 } from '../constants/ui';
 
 export function increaseFontSize () {
@@ -150,6 +151,17 @@ export function showPreferences () {
             ));
           });
         });
+      }
+    });
+  };
+}
+
+export function windowMove () {
+  return (dispatch) => {
+    dispatch({
+      type: UI_WINDOW_MOVE,
+      effect () {
+        dispatch(setFontSmoothing());
       }
     });
   };

--- a/app/lib/actions/ui.js
+++ b/app/lib/actions/ui.js
@@ -11,6 +11,7 @@ import {
   UI_FONT_SIZE_INCR,
   UI_FONT_SIZE_DECR,
   UI_FONT_SIZE_RESET,
+  UI_FONT_SMOOTHING_SET,
   UI_MOVE_LEFT,
   UI_MOVE_RIGHT,
   UI_MOVE_TO,
@@ -54,6 +55,18 @@ export function decreaseFontSize () {
 export function resetFontSize () {
   return {
     type: UI_FONT_SIZE_RESET
+  };
+}
+
+export function setFontSmoothing () {
+  const devicePixelRatio = window.devicePixelRatio;
+  const fontSmoothing = devicePixelRatio < 2
+    ? 'subpixel-antialiased'
+    : 'antialiased';
+
+  return {
+    type: UI_FONT_SMOOTHING_SET,
+    fontSmoothing
   };
 }
 

--- a/app/lib/components/term.js
+++ b/app/lib/components/term.js
@@ -26,7 +26,7 @@ export default class Term extends Component {
 
     this.term.prefs_.set('font-family', props.fontFamily);
     this.term.prefs_.set('font-size', props.fontSize);
-    this.term.prefs_.set('font-smoothing', this.getFontSmoothing());
+    this.term.prefs_.set('font-smoothing', props.fontSmoothing);
     this.term.prefs_.set('cursor-color', props.cursorColor);
     this.term.prefs_.set('enable-clipboard-notice', false);
     this.term.prefs_.set('foreground-color', props.foregroundColor);
@@ -104,16 +104,6 @@ export default class Term extends Component {
     return URL.createObjectURL(blob, { type: 'text/css' });
   }
 
-  getFontSmoothing () {
-    this.devicePixelRatio = window.devicePixelRatio;
-
-    if (this.devicePixelRatio < 2) {
-      return 'subpixel-antialiased';
-    }
-
-    return 'antialiased';
-  }
-
   componentWillReceiveProps (nextProps) {
     if (this.props.url !== nextProps.url) {
       // when the url prop changes, we make sure
@@ -152,6 +142,10 @@ export default class Term extends Component {
       this.term.prefs_.set('font-family', nextProps.fontFamily);
     }
 
+    if (this.props.fontSmoothing !== nextProps.fontSmoothing) {
+      this.term.prefs_.set('font-smoothing', props.fontSmoothing);
+    }
+
     if (this.props.cursorColor !== nextProps.cursorColor) {
       this.term.prefs_.set('cursor-color', nextProps.cursorColor);
     }
@@ -162,10 +156,6 @@ export default class Term extends Component {
 
     if (this.props.customCSS !== nextProps.customCSS) {
       this.term.prefs_.set('user-css', this.getStylesheet(nextProps.customCSS));
-    }
-
-    if (this.devicePixelRatio !== window.devicePixelRatio) {
-      this.term.prefs_.set('font-smoothing', this.getFontSmoothing());
     }
   }
 

--- a/app/lib/components/term.js
+++ b/app/lib/components/term.js
@@ -26,6 +26,7 @@ export default class Term extends Component {
 
     this.term.prefs_.set('font-family', props.fontFamily);
     this.term.prefs_.set('font-size', props.fontSize);
+    this.term.prefs_.set('font-smoothing', this.getFontSmoothing());
     this.term.prefs_.set('cursor-color', props.cursorColor);
     this.term.prefs_.set('enable-clipboard-notice', false);
     this.term.prefs_.set('foreground-color', props.foregroundColor);
@@ -103,6 +104,16 @@ export default class Term extends Component {
     return URL.createObjectURL(blob, { type: 'text/css' });
   }
 
+  getFontSmoothing () {
+    this.devicePixelRatio = window.devicePixelRatio;
+
+    if (this.devicePixelRatio < 2) {
+      return 'subpixel-antialiased';
+    }
+
+    return 'antialiased';
+  }
+
   componentWillReceiveProps (nextProps) {
     if (this.props.url !== nextProps.url) {
       // when the url prop changes, we make sure
@@ -151,6 +162,10 @@ export default class Term extends Component {
 
     if (this.props.customCSS !== nextProps.customCSS) {
       this.term.prefs_.set('user-css', this.getStylesheet(nextProps.customCSS));
+    }
+
+    if (this.devicePixelRatio !== window.devicePixelRatio) {
+      this.term.prefs_.set('font-smoothing', this.getFontSmoothing());
     }
   }
 

--- a/app/lib/components/terms.js
+++ b/app/lib/components/terms.js
@@ -129,6 +129,7 @@ export default class Terms extends Component {
             fontSize: this.props.fontSize,
             cursorColor: this.props.cursorColor,
             fontFamily: this.props.fontFamily,
+            fontSmoothing: this.props.fontSmoothing,
             foregroundColor: this.props.foregroundColor,
             backgroundColor: this.props.backgroundColor,
             colors: this.props.colors,

--- a/app/lib/constants/ui.js
+++ b/app/lib/constants/ui.js
@@ -2,6 +2,7 @@ export const UI_FONT_SIZE_SET = 'UI_FONT_SIZE_SET';
 export const UI_FONT_SIZE_INCR = 'UI_FONT_SIZE_INCR';
 export const UI_FONT_SIZE_DECR = 'UI_FONT_SIZE_DECR';
 export const UI_FONT_SIZE_RESET = 'UI_FONT_SIZE_RESET';
+export const UI_FONT_SMOOTHING_SET = 'UI_FONT_SMOOTHING_SET';
 export const UI_MOVE_LEFT = 'UI_MOVE_LEFT';
 export const UI_MOVE_RIGHT = 'UI_MOVE_RIGHT';
 export const UI_MOVE_TO = 'UI_MOVE_TO';

--- a/app/lib/constants/ui.js
+++ b/app/lib/constants/ui.js
@@ -7,3 +7,4 @@ export const UI_MOVE_LEFT = 'UI_MOVE_LEFT';
 export const UI_MOVE_RIGHT = 'UI_MOVE_RIGHT';
 export const UI_MOVE_TO = 'UI_MOVE_TO';
 export const UI_SHOW_PREFERENCES = 'UI_SHOW_PREFERENCES';
+export const UI_WINDOW_MOVE = 'UI_WINDOW_MOVE';

--- a/app/lib/containers/terms.js
+++ b/app/lib/containers/terms.js
@@ -23,6 +23,7 @@ const TermsContainer = connect(
         ? state.ui.fontSizeOverride
         : state.ui.fontSize,
       fontFamily: state.ui.fontFamily,
+      fontSmoothing: state.ui.fontSmoothingOverride,
       padding: state.ui.padding,
       cursorColor: state.ui.cursorColor,
       borderColor: state.ui.borderColor,

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -101,7 +101,7 @@ rpc.on('update available', ({ releaseName, releaseNotes }) => {
 });
 
 rpc.on('move', () => {
-  store_.dispatch(uiActions.setFontSmoothing());
+  store_.dispatch(uiActions.windowMove());
 });
 
 const app = render(

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -41,6 +41,7 @@ config.subscribe(() => {
 // and subscribe to all user intents for example from menus
 rpc.on('ready', () => {
   store_.dispatch(init());
+  store_.dispatch(uiActions.setFontSmoothing());
 });
 
 rpc.on('session add', ({ uid, shell, pid }) => {
@@ -97,6 +98,10 @@ rpc.on('preferences', () => {
 
 rpc.on('update available', ({ releaseName, releaseNotes }) => {
   store_.dispatch(updaterActions.updateAvailable(releaseName, releaseNotes));
+});
+
+rpc.on('move', () => {
+  store_.dispatch(uiActions.setFontSmoothing());
 });
 
 const app = render(

--- a/app/lib/reducers/ui.js
+++ b/app/lib/reducers/ui.js
@@ -1,7 +1,11 @@
 import Immutable from 'seamless-immutable';
 import { decorateUIReducer } from '../utils/plugins';
 import { CONFIG_LOAD, CONFIG_RELOAD } from '../constants/config';
-import { UI_FONT_SIZE_SET, UI_FONT_SIZE_RESET } from '../constants/ui';
+import {
+  UI_FONT_SIZE_SET,
+  UI_FONT_SIZE_RESET,
+  UI_FONT_SMOOTHING_SET
+} from '../constants/ui';
 import { NOTIFICATION_DISMISS } from '../constants/notifications';
 import {
   SESSION_ADD,
@@ -23,6 +27,7 @@ const initial = Immutable({
   padding: '12px 14px',
   fontFamily: 'Menlo, "DejaVu Sans Mono", "Lucida Console", monospace',
   fontSizeOverride: null,
+  fontSmoothingOverride: 'antialiased',
   css: '',
   termCSS: '',
   openAt: {},
@@ -188,6 +193,10 @@ const reducer = (state = initial, action) => {
 
     case UI_FONT_SIZE_RESET:
       state_ = state.set('fontSizeOverride', null);
+      break;
+
+    case UI_FONT_SMOOTHING_SET:
+      state_ = state.set('fontSmoothingOverride', action.fontSmoothing);
       break;
 
     case NOTIFICATION_DISMISS:

--- a/index.js
+++ b/index.js
@@ -154,6 +154,10 @@ app.on('ready', () => {
       shell.openExternal(url);
     });
 
+    rpc.win.on('move', () => {
+      rpc.emit('move');
+    });
+
     const deleteSessions = () => {
       sessions.forEach((session, key) => {
         session.removeAllListeners();


### PR DESCRIPTION
By default, hterm defaults to `font-smoothing: 'antialiased'`, which
works really well on retina displays. On non-retina displays, however,
the type looks very thin and is hard to read.

This will look at the devicePixelRatio of the device anytime the term
prefs are set, and change between `antialiased` and
`subpixel-antialiased` dynamically.

Screenshots below.
<details>
#### retina (👍)
![retina](https://cloud.githubusercontent.com/assets/464447/16901809/d527e4c6-4c0a-11e6-97ed-9add138fcc03.png)

#### non-retina, before (👎)
![non-retina-pre](https://cloud.githubusercontent.com/assets/464447/16901810/de3982ea-4c0a-11e6-9957-ec68b01ae618.png)

#### non-retina, after (👍)
![non-retina-post](https://cloud.githubusercontent.com/assets/464447/16901812/e19a94ce-4c0a-11e6-986f-42f9ae6d16e7.png)
</details>