### PR TITLE
Add cursor actions

### DIFF
--- a/app/lib/components/term.js
+++ b/app/lib/components/term.js
@@ -96,6 +96,34 @@ export default class Term extends Component {
     }
   }
 
+  moveWordLeft () {
+    this.term.onVTKeystroke('\x1bb');
+  }
+
+  moveWordRight () {
+    this.term.onVTKeystroke('\x1bf');
+  }
+
+  deleteWordLeft () {
+    this.term.onVTKeystroke('\x1b\x7f');
+  }
+
+  deleteWordRight () {
+    this.term.onVTKeystroke('\x1bd');
+  }
+
+  deleteLine () {
+    this.term.onVTKeystroke('\x1bw');
+  }
+
+  moveToStart () {
+    this.term.onVTKeystroke('\x01');
+  }
+
+  moveToEnd () {
+    this.term.onVTKeystroke('\x05');
+  }
+
   getTermDocument () {
     return this.term.document_;
   }

--- a/app/lib/containers/hyperterm.js
+++ b/app/lib/containers/hyperterm.js
@@ -49,6 +49,17 @@ class HyperTerm extends Component {
     keys.bind('command+shift+]', moveRight);
     keys.bind('command+alt+left', moveLeft);
     keys.bind('command+alt+right', moveRight);
+
+    const bound = method => { return term[method].bind(term) }
+    keys.bind('alt+left', bound('moveWordLeft'));
+    keys.bind('alt+right', bound('moveWordRight'));
+    keys.bind('alt+backspace', bound('deleteWordLeft'));
+    keys.bind('alt+del', bound('deleteWordRight'));
+    keys.bind('command+left', bound('deleteWordLeft'));
+    keys.bind('command+right', bound('deleteWordRight'));
+    keys.bind('command+backspace', bound('deleteLine'));
+    keys.bind('command+left', bound('moveToStart'));
+    keys.bind('command+right', bound('moveToEnd'));
     this.keys = keys;
   }
 

--- a/app/lib/hterm.js
+++ b/app/lib/hterm.js
@@ -29,7 +29,7 @@ hterm.Terminal.prototype.copySelectionToClipboard = function () {
 // hyperterm and not the terminal itself
 const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
 hterm.Keyboard.prototype.onKeyDown_ = function (e) {
-  if (e.metaKey) {
+  if (e.metaKey || e.altKey) {
     return;
   }
   return oldKeyDown.call(this, e);

--- a/menu.js
+++ b/menu.js
@@ -216,7 +216,7 @@ module.exports = function createMenu ({ createWindow, updatePlugins }) {
         },
         {
           label: 'Show Previous Tab',
-          accelerator: 'CmdOrCtrl+Left',
+          accelerator: 'CmdOrCtrl+Option+Left',
           click (item, focusedWindow) {
             if (focusedWindow) {
               focusedWindow.rpc.emit('move left req');
@@ -225,7 +225,7 @@ module.exports = function createMenu ({ createWindow, updatePlugins }) {
         },
         {
           label: 'Show Next Tab',
-          accelerator: 'CmdOrCtrl+Right',
+          accelerator: 'CmdOrCtrl+Option+Right',
           click (item, focusedWindow) {
             if (focusedWindow) {
               focusedWindow.rpc.emit('move right req');


### PR DESCRIPTION
This makes `alt + <`, `alt + >`, `alt + delete` work
Fixes #53 #157
WIP

There's one open question. How do we want to trigger those methods?
Should I add a new variable in here?https://github.com/zeit/hyperterm/blame/master/app/lib/components/terms.js#L21-L23

 Or just set it up in the ui and don't use commands and reducers? 