### PR TITLE
Add `displayTitleCwd` configuration

### DIFF
--- a/app/lib/reducers/ui.js
+++ b/app/lib/reducers/ui.js
@@ -53,6 +53,7 @@ const initial = Immutable({
   },
   foregroundColor: '#fff',
   backgroundColor: '#000',
+  displayTitleCwd: true,
   updateVersion: null,
   updateNotes: null
 });
@@ -113,6 +114,12 @@ const reducer = (state = initial, action) => {
         if (null != config.colors) {
           if (state.colors.toString() !== config.colors.toString()) {
             ret.colors = config.colors;
+          }
+        }
+
+        if (null != config.displayTitleCwd) {
+          if (state.displayTitleCwd.toString() !== config.displayTitleCwd.toString()) {
+            ret.displayTitleCwd = config.displayTitleCwd;
           }
         }
 

--- a/config-default.js
+++ b/config-default.js
@@ -48,6 +48,9 @@ module.exports = {
       '#ffffff'
     ],
 
+    // display cwd before process title
+    displayTitleCwd: true,
+
     // the shell to run when spawning a new session (i.e. /usr/local/bin/fish)
     // if left empty, your system's login shell will be used by default
     shell: ''

--- a/session.js
+++ b/session.js
@@ -126,7 +126,7 @@ module.exports = class Session extends EventEmitter {
         this.emit('title', title);
         this.lastTitle = title;
       }
-    }).catch((error) => {
+    }).catch(() => {
       // do nothing
     })
 

--- a/session.js
+++ b/session.js
@@ -1,3 +1,4 @@
+const { homedir } = require('os');
 const { EventEmitter } = require('events');
 const { exec } = require('child_process');
 const defaultShell = require('default-shell');
@@ -14,6 +15,7 @@ try {
   );
 }
 
+const { getConfig } = require('./config');
 const TITLE_POLL_INTERVAL = 500;
 
 module.exports = class Session extends EventEmitter {
@@ -54,6 +56,51 @@ module.exports = class Session extends EventEmitter {
     clearTimeout(this.titlePoll);
   }
 
+  getCurrentWorkingDirectory (pid) {
+    return new Promise((resolve, reject) => {
+      // TODO: only tested on mac
+      exec(`lsof -p ${pid} | grep cwd`, (err, out) => {
+        if (this.ended || err) {
+          reject();
+          return;
+        }
+
+        // TODO: can homedir() be ran just once?
+        const homeDirectory = homedir();
+        let cwd = out.split(' ').pop();
+
+        if (cwd.substr(0, homeDirectory.length) === homeDirectory) {
+          cwd = cwd.replace(homeDirectory, '~');
+        }
+
+        resolve(cwd);
+      });
+    });
+  }
+
+  getCurrentProcess (tty) {
+    return new Promise((resolve, reject) => {
+      // TODO: limit the concurrency of how many processes we run?
+      // TODO: only tested on mac
+      exec(`ps uxac | grep ${tty} | head -n 1`, (err, out) => {
+        if (this.ended || err) {
+          reject();
+          return;
+        }
+
+        const [user, pid, ...fragments] = out.split(' ');
+        let title = fragments.pop();
+
+        if (title) {
+          title = title.replace(/^\(/, '');
+          title = title.replace(/\)?\n$/, '');
+        }
+
+        resolve({user, pid, title});
+      });
+    });
+  }
+
   getTitle () {
     if ('win32' === process.platform) return;
     if (this.fetching) return;
@@ -66,20 +113,20 @@ module.exports = class Session extends EventEmitter {
     // by grepping for `[s]001` instead of `s001`
     tty = `[${tty[0]}]${tty.substr(1)}`;
 
-    // TODO: limit the concurrency of how many processes we run?
-    // TODO: only tested on mac
-    exec(`ps uxac | grep ${tty} | head -n 1`, (err, out) => {
+    this.getCurrentProcess(tty).then(({ user, pid, title }) => {
+      if (pid && getConfig().displayTitleCwd) {
+        return this.getCurrentWorkingDirectory(pid).then((cwd) => {
+          return `${cwd} – ${title}`;
+        });
+      }
+
+      return title;
+    }).then((title) => {
       this.fetching = false;
-      if (this.ended) return;
-      if (err) return;
-      let title = out.split(' ').pop();
-      if (title) {
-        title = title.replace(/^\(/, '');
-        title = title.replace(/\)?\n$/, '');
-        if (title !== this.lastTitle) {
-          this.emit('title', title);
-          this.lastTitle = title;
-        }
+
+      if (title !== this.lastTitle) {
+        this.emit('title', title);
+        this.lastTitle = title;
       }
 
       if (this.subscribed) {


### PR DESCRIPTION
This implements a configuration I'm very fond of in `Terminal.app`: Working directory in tab title. Particularly useful when you have multiple tabs open running the same process, eg. `node`.

<img width="582" alt="screen shot 2016-07-18 at 02 15 12" src="https://cloud.githubusercontent.com/assets/2833514/16903988/7fab8632-4c8d-11e6-8a16-2fe994a13a2b.png">

This could probably also be a menu item under `View` with a check box next to it if active.