### PR TITLE
Use #ffffff instead of #fff for foreground color as the short form seems to mess up.

### DIFF
--- a/app/lib/reducers/ui.js
+++ b/app/lib/reducers/ui.js
@@ -51,7 +51,7 @@ const initial = Immutable({
     resize: false,
     updates: false
   },
-  foregroundColor: '#fff',
+  foregroundColor: '#ffffff',
   backgroundColor: '#000',
   updateVersion: null,
   updateNotes: null

--- a/config-default.js
+++ b/config-default.js
@@ -10,7 +10,7 @@ module.exports = {
     cursorColor: '#F81CE5',
 
     // color of the text
-    foregroundColor: '#fff',
+    foregroundColor: '#ffffff',
 
     // terminal background color
     backgroundColor: '#000',


### PR DESCRIPTION
Hey @rauchg, 

This PR fixes https://github.com/zeit/hyperterm/issues/177 and https://github.com/zeit/hyperterm/issues/199, which looks like a dupe of the former. 

It seems that for some reason, using `#fff` as the hex value for foreground correctly makes the text white, but highlighted texts are in a barely readable gray color. Using the full form `#ffffff` or `white` instead correctly makes both text and highlighted text white. 

Before: 

![screen shot 2016-07-17 at 11 21 57 pm](https://cloud.githubusercontent.com/assets/1296641/16905187/93640f88-4c78-11e6-889f-f5826cfe433e.png)

After: 

![screen shot 2016-07-17 at 11 20 53 pm](https://cloud.githubusercontent.com/assets/1296641/16905188/99664004-4c78-11e6-8b54-cb9f6ef964d2.png)

Please check it out, thanks! 