### PR TITLE
Prevents header from rendering with one tab

### DIFF
--- a/app/lib/components/header.js
+++ b/app/lib/components/header.js
@@ -60,6 +60,7 @@ export default class Header extends Component {
       onClose: this.props.onCloseTab,
       onChange: this.onChangeIntent
     });
+
     return <header
       style={{ backgroundColor }}
       className={ css('header', isMac && 'headerRounded') }

--- a/app/lib/components/terms.js
+++ b/app/lib/components/terms.js
@@ -114,9 +114,10 @@ export default class Terms extends Component {
   }
 
   template (css) {
+    const isFullScreen = this.props.isFullScreen;
     return <div
       style={{ padding: this.props.padding }}
-      className={ css('terms') }>
+      className={ css('terms', isFullScreen && 'tabsHidden') }>
       { this.props.customChildrenBefore }
       {
         this.props.sessions.map((session) => {
@@ -157,12 +158,20 @@ export default class Terms extends Component {
     return {
       terms: {
         position: 'absolute',
-        marginTop: '34px',
         top: 0,
         right: 0,
         left: 0,
         bottom: 0,
-        color: '#fff'
+        color: '#fff',
+        marginTop: '34px'
+      },
+
+      tabsHidden: {
+        marginTop: 0
+      },
+
+      tabsVisible: {
+        marginTop: '34px'
       },
 
       term: {

--- a/app/lib/containers/hyperterm.js
+++ b/app/lib/containers/hyperterm.js
@@ -70,12 +70,12 @@ class HyperTerm extends Component {
   }
 
   template (css) {
-    const { isMac, customCSS, borderColor } = this.props;
+    const { isMac, customCSS, borderColor, isFullScreen } = this.props;
     return <div onClick={ this.focusActive }>
       <div
         style={{ borderColor }}
         className={ css('main', isMac && 'mainRounded') }>
-        <HeaderContainer />
+        {isFullScreen ? null : <HeaderContainer />}
         <TermsContainer ref_={this.onTermsRef} />
       </div>
 
@@ -111,7 +111,8 @@ const HyperTermContainer = connect(
       customCSS: state.ui.css,
       borderColor: state.ui.borderColor,
       activeSession: state.sessions.activeUid,
-      backgroundColor: state.ui.backgroundColor
+      backgroundColor: state.ui.backgroundColor,
+      isFullScreen: state.ui.fullScreenMode
     };
   },
   (dispatch) => {

--- a/app/lib/containers/terms.js
+++ b/app/lib/containers/terms.js
@@ -28,7 +28,8 @@ const TermsContainer = connect(
       borderColor: state.ui.borderColor,
       colors: state.ui.colors,
       foregroundColor: state.ui.foregroundColor,
-      backgroundColor: state.ui.backgroundColor
+      backgroundColor: state.ui.backgroundColor,
+      isFullScreen: state.ui.fullScreenMode
     };
   },
   (dispatch) => {

--- a/app/lib/reducers/ui.js
+++ b/app/lib/reducers/ui.js
@@ -116,6 +116,10 @@ const reducer = (state = initial, action) => {
           }
         }
 
+        if (null != config.fullScreenMode) {
+          ret.fullScreenMode = config.fullScreenMode;
+        }
+
         return ret;
       })());
       break;

--- a/index.js
+++ b/index.js
@@ -96,9 +96,13 @@ app.on('ready', () => {
           rpc.emit('session data', { uid, data });
         });
 
-        session.on('title', (title) => {
-          rpc.emit('session title', { uid, title });
-        });
+        // No need to extract the title if hyperterm is
+        // being used in fullscreen/tiling wm mode
+        if(!cfg.fullScreenMode) {
+          session.on('title', (title) => {
+            rpc.emit('session title', { uid, title });
+          });
+        }
 
         session.on('exit', () => {
           rpc.emit('session exit', { uid });


### PR DESCRIPTION
Small tweaks to ensure that when there are <= 1 tabs, the `<Header />` component renders `null` rather than `<header>`. Also changes the style in `<Terms />` to make sure that the 34px top margin is only rendered if there are enough tabs open to justify it.

![Example](http://i.imgur.com/sEz4U79.gif)

For everyone using TMUX rather than native tabs, this should make hyperterm a viable option. I don't actually run OSX to test it on, so it's worth checking that the removed margin doesn't cause any visual accidents there.

Fixes #127 and #92.

I've been dreaming about a web powered terminal forever. Great job!