### PR TITLE
Remove unnecessary/odd addEventListener in Term component unmount hook

### DIFF
--- a/app/lib/components/term.js
+++ b/app/lib/components/term.js
@@ -162,8 +162,6 @@ export default class Term extends Component {
   }
 
   componentWillUnmount () {
-    const iframeWindow = this.getTermDocument().defaultView;
-    iframeWindow.addEventListener('wheel', this.onWheel);
     clearTimeout(this.scrollbarsHideTimer);
     this.props.ref_(null);
   }


### PR DESCRIPTION
Since the node is already being removed, the frame will be destroyed.