### PR TITLE
Support config for default width/height of browser window

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,10 +48,11 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
   function createWindow (fn) {
     const cfg = plugins.getDecoratedConfig();
+    const [width, height] = cfg.windowSize || [540, 380];
 
     const browserDefaults = {
-      width: 540,
-      height: 380,
+      width,
+      height,
       minHeight: 190,
       minWidth: 370,
       titleBarStyle: 'hidden-inset',


### PR DESCRIPTION
This addresses #108 (sort of). Ideally I think rows/cols make more sense since this is a terminal application. This at least gives the user something to work with.