### PR TITLE
Move to the last tab with cmd + 9

### DIFF
--- a/app/lib/components/terms.js
+++ b/app/lib/components/terms.js
@@ -90,6 +90,10 @@ export default class Terms extends Component {
     return this.getTermByUid(this.props.activeSession);
   }
 
+  getLastTermIndex () {
+    return this.props.sessions.length - 1;
+  }
+
   bind (fn, thisObj, uid) {
     if (!this.bound.has(fn)) {
       this.bound.set(fn, {});

--- a/app/lib/containers/hyperterm.js
+++ b/app/lib/containers/hyperterm.js
@@ -32,6 +32,7 @@ class HyperTerm extends Component {
     const { moveTo, moveLeft, moveRight } = this.props;
     const term = this.terms.getActiveTerm();
     if (!term) return;
+    const lastIndex = this.terms.getLastTermIndex();
     const document = term.getTermDocument();
     const keys = new Mousetrap(document);
     keys.bind('command+1', moveTo.bind(this, 0));
@@ -42,7 +43,8 @@ class HyperTerm extends Component {
     keys.bind('command+6', moveTo.bind(this, 5));
     keys.bind('command+7', moveTo.bind(this, 6));
     keys.bind('command+8', moveTo.bind(this, 7));
-    keys.bind('command+9', moveTo.bind(this, 8));
+    keys.bind('command+9', moveTo.bind(this, lastIndex));
+
     keys.bind('command+shift+left', moveLeft);
     keys.bind('command+shift+right', moveRight);
     keys.bind('command+shift+[', moveLeft);


### PR DESCRIPTION
This mimics the behavior of Chrome, Firefox, iTerm 2 and similar, by moving to the last possible tab when Command + 9 is pressed.

Fixes #255.