### PR TITLE
Close window when last tab is exited

### DIFF
--- a/app/lib/actions/sessions.js
+++ b/app/lib/actions/sessions.js
@@ -103,13 +103,10 @@ export function userExitSession (uid) {
       type: SESSION_USER_EXIT,
       uid,
       effect () {
-        const { sessions } = getState().sessions;
-        if (sessions[uid]) {
-          rpc.emit('exit', { uid });
-          const sessions = keys(getState().sessions.sessions);
-          if (!sessions.length) {
-            window.close();
-          }
+        rpc.emit('exit', { uid });
+        const sessions = keys(getState().sessions.sessions);
+        if (!sessions.length) {
+          window.close();
         }
       }
     });


### PR DESCRIPTION
I might be completely wrong here, but it seemed to me that the intention of `userExitSession` was to close the window if the last tab is closed - instead of leaving a ghost window like the one in the screenshot below. However, with the current logic the session would be deleted in the reducer [here](https://github.com/zeit/hyperterm/blob/master/app/lib/reducers/sessions.js#L88) before the effect function is called, and thus the if-body is never reached (since the session doesn't exist).

This commit removes that check, so that the window is correctly closed if there's no tabs left. The previous behavior also resulted in `rpc.emit('exit', { uid });` not being called when a tab was closed, but if this is the intended behavior and I'm missing something crucial - let me know. 

![image](https://cloud.githubusercontent.com/assets/3536982/16931322/b32f3450-4d40-11e6-8f48-44649b71d450.png)
