### PR TITLE
Make preference-opening command universal

### DIFF
--- a/app/lib/actions/ui.js
+++ b/app/lib/actions/ui.js
@@ -131,7 +131,7 @@ export function showPreferences () {
               uid,
               ['# Attempting to open ~/.hyperterm.js with your $EDITOR',
                '# If this doesn\'t work, open it manually with your favorite editor!',
-               '$EDITOR ~/.hyperterm.js && exit',
+               'exec env $EDITOR ~/.hyperterm.js',
                ''
               ].join('\n')
             ));


### PR DESCRIPTION
The `$EDITOR ~/.hyperterm.js && exit` requires that the default shell recognize variables as commands and to recognize the `&&` syntax, so it does not work with fish shell. The new command works with all common shells, including fish.

Old behavior with `fish`:

<img width="540" alt="screen shot 2016-07-18 at 4 05 52 pm" src="https://cloud.githubusercontent.com/assets/1570168/16933361/84c24984-4d01-11e6-9bba-f80f0981963c.png">
