### PR TITLE
Override the buggy hexToRGB implementation in hterm.

### DIFF
--- a/app/lib/hterm.js
+++ b/app/lib/hterm.js
@@ -86,5 +86,37 @@ hterm.Terminal.prototype.clearPreserveCursorRow = function () {
   this.scrollPort_.redraw_();
 };
 
+// fixes a bug in hterm, where the shorthand hex
+// is not properly converted to rgb
+lib.colors.hexToRGB = function(arg) {
+  var hex16 = lib.colors.re_.hex16;
+  var hex24 = lib.colors.re_.hex24;
+
+  function convert(hex) {
+    if (hex.length == 4) {
+      hex = hex.replace(hex16, function(h, r, g, b) {
+        return "#" + r + r + g + g + b + b;
+      });
+    }
+    var ary = hex.match(hex24);
+    if (!ary)
+      return null;
+
+    return 'rgb(' + parseInt(ary[1], 16) + ', ' +
+          parseInt(ary[2], 16) + ', ' +
+          parseInt(ary[3], 16) + ')';
+  }
+
+  if (arg instanceof Array) {
+    for (var i = 0; i < arg.length; i++) {
+      arg[i] = convert(arg[i]);
+    }
+  } else {
+    arg = convert(arg);
+  }
+
+  return arg;
+};
+
 export default hterm;
 export { lib };


### PR DESCRIPTION
Hey @rauchg, 

This PR fixes the issue we've seen with colors and discussed in #220. The problem is in https://github.com/dbkaplun/hterm-umdjs/blob/master/dist/index.js#L343-L376. 

Instead of converting the hex "FF" to decimal (255), it was converting just "F", which resulted in 15, and the gray `rgb(15, 15, 15)` color instead of `rgb(255, 255, 255)`. The shorthand was not being expanded properly. 

Let me know if I should move the code elsewhere from hterm or if we should solve this problem some other way. 

Please check it out, thanks! 