### PR TITLE
Implement support for opening files.

### DIFF
--- a/app/lib/constants/ui.js
+++ b/app/lib/constants/ui.js
@@ -6,3 +6,4 @@ export const UI_MOVE_LEFT = 'UI_MOVE_LEFT';
 export const UI_MOVE_RIGHT = 'UI_MOVE_RIGHT';
 export const UI_MOVE_TO = 'UI_MOVE_TO';
 export const UI_SHOW_PREFERENCES = 'UI_SHOW_PREFERENCES';
+export const UI_OPEN_FILE = 'UI_OPEN_FILE';

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -95,6 +95,10 @@ rpc.on('preferences', () => {
   store_.dispatch(uiActions.showPreferences());
 });
 
+rpc.on('open file', ({ path }) => {
+  store_.dispatch(uiActions.openFile(path));
+});
+
 rpc.on('update available', ({ releaseName, releaseNotes }) => {
   store_.dispatch(updaterActions.updateAvailable(releaseName, releaseNotes));
 });

--- a/app/lib/utils/string.js
+++ b/app/lib/utils/string.js
@@ -1,0 +1,3 @@
+export function escapeShellArgument (text) {
+	return text.replace(/[ \(\)\[\]<>\\\|'"`;!\?#\$&\*]/g, "\\$1");
+}

--- a/app/lib/utils/string.js
+++ b/app/lib/utils/string.js
@@ -1,3 +1,3 @@
 export function escapeShellArgument (text) {
-	return text.replace(/[ \(\)\[\]<>\\\|'"`;!\?#\$&\*]/g, "\\$1");
+	return text.replace(/([ \(\)\[\]<>\\\|'"`;!\?#\$&\*])/g, '\\$1');
 }

--- a/index.js
+++ b/index.js
@@ -255,3 +255,14 @@ function initSession (opts, fn) {
     fn(uid, new Session(opts));
   });
 }
+
+app.on('open-file', (event, path) => {
+  const callback = win => win.rpc.emit('open file', { path });
+  if (lastWindow) {
+    callback(lastWindow);
+  } else {
+    // TODO: This causes two tabs to be created; the default tab upon creating a
+    // new window, and the tab used to open the URL.
+    app.createWindow(callback);
+  }
+});

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ config.init();
 const plugins = require('./plugins');
 
 const windowSet = new Set([]);
+var lastWindow;
 
 // expose to plugins
 app.config = config;
@@ -63,6 +64,8 @@ app.on('ready', () => {
     });
 
     windowSet.add(win);
+    lastWindow = win;
+
     win.loadURL(url);
 
     const rpc = createRPC(win);
@@ -195,8 +198,14 @@ app.on('ready', () => {
       }
     });
 
+    win.on('focus', () => {
+      lastWindow = win;
+    })
+
     // the window can be closed by the browser process itself
     win.on('close', () => {
+      // TODO: lastWindow should be set to another window, if one exists.
+      lastWindow = undefined;
       windowSet.delete(win);
       rpc.destroy();
       deleteSessions();


### PR DESCRIPTION
Nice project! Wanted to contribute a quick little feature.

This implements the `open-file` event on `app`, which is fired when one of the following happens:

* A file is launched (ie, double-click in Finder), and the file’s type is set to be handled by HyperTerm.
* A file is dropped onto the dock icon.
* The user runs `open -b co.zeit.hyperterm blah.sh`, or [equivalent](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSWorkspace_Class/#//apple_ref/occ/instm/NSWorkspace/openURLs:withAppBundleIdentifier:options:additionalEventParamDescriptor:launchIdentifiers:) in Cocoa. (This adds support with my own [TermHere](https://hbang.com.au/termhere).)

The implementation works like this:

1. The last used window is tracked, based on the last one spawned or `focus`ed (8a4bbd1).
2. When the event is fired, if a window exists, we send an `open file` command to it; otherwise we create a new window and send it to that (a495b3f).
3. The path given is escaped to be used as a shell argument (8db2ad8). If it’s a directory, prepend `cd`.
4. Write the command to the TTY.

Bugs – I’m not too sure how these should be fixed:

* When closing a window, with other windows open but minimised, `lastWindow` will be undefined as another window hasn’t gained focus. This also assumes the window manager will give focus to another window from the same app, which I don’t think is the case on Windows.
* When opening a new window, two tabs are created. The first is the default one created automatically; the second is the one created by the `open-file` event.