### PR TITLE
Fix preferences shortcut with zsh #88

### DIFF
--- a/app/lib/actions/ui.js
+++ b/app/lib/actions/ui.js
@@ -129,8 +129,8 @@ export function showPreferences () {
           rpc.once('session data', () => {
             dispatch(sendSessionData(
               uid,
-              ['# Attempting to open ~/.hyperterm.js with your $EDITOR',
-               '# If this doesn\'t work, open it manually with your favorite editor!',
+              ['echo Attempting to open ~/.hyperterm.js with your \$EDITOR',
+               'echo If it fails, open it manually with your favorite editor!',
                'exec env $EDITOR ~/.hyperterm.js',
                ''
               ].join('\n')


### PR DESCRIPTION
Fix the comments for zsh (#88)

Before: 
![capture d ecran 2016-07-19 a 14 07 07](https://cloud.githubusercontent.com/assets/2368736/16949414/fe18e7fc-4dba-11e6-8f63-59e855335530.png)
After:
![capture d ecran 2016-07-19 a 14 07 52](https://cloud.githubusercontent.com/assets/2368736/16949424/048d7b02-4dbb-11e6-9d8c-20b33a4c8106.png)

tested with bash / fish / zsh