### PR TITLE
Fix installing plugins that use `node-gyp`

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -194,7 +194,7 @@ function install (fn) {
     let registry = exports.getDecoratedConfig().npmRegistry;
     if (registry) env.NPM_CONFIG_REGISTRY = registry;
     env.npm_config_runtime = 'electron';
-    env.npm_config_target = '1.2.5';
+    env.npm_config_target = require('./package.json').devDependencies['electron-prebuilt'];
     env.npm_config_disturl = 'https://atom.io/download/atom-shell';
     exec('npm prune && npm install --production', {
       cwd: path,

--- a/plugins.js
+++ b/plugins.js
@@ -193,6 +193,9 @@ function install (fn) {
   shellEnv().then((env) => {
     let registry = exports.getDecoratedConfig().npmRegistry;
     if (registry) env.NPM_CONFIG_REGISTRY = registry;
+    env.npm_config_runtime = 'electron';
+    env.npm_config_target = '1.2.5';
+    env.npm_config_disturl = 'https://atom.io/download/atom-shell';
     exec('npm prune && npm install --production', {
       cwd: path,
       env: env


### PR DESCRIPTION
Sets the proper environmental variables to install plugins that have
specific needs for compilation e.g. `nodegit`.

I came across this issue with a plugin I recently created [`hyperterm-sync-settings`](https://github.com/dfrankland/hyperterm-sync-settings) which would build dependencies from source improperly. This change fixes that.