### PR TITLE
Fix prop update logic for fontSmoothing

### DIFF
--- a/app/lib/components/term.js
+++ b/app/lib/components/term.js
@@ -177,7 +177,7 @@ export default class Term extends Component {
     }
 
     if (this.props.fontSmoothing !== nextProps.fontSmoothing) {
-      this.term.prefs_.set('font-smoothing', props.fontSmoothing);
+      this.term.prefs_.set('font-smoothing', nextProps.fontSmoothing);
     }
 
     if (this.props.cursorColor !== nextProps.cursorColor) {


### PR DESCRIPTION
This fixes a bug I introduced in #205 where the old prop was being used instead of `nextProp`. Found by @nfcampos [in this commit](https://github.com/zeit/hyperterm/commit/b76e0043091cedd4b30ef8d10dbc724c9578a2b3#commitcomment-18305818).