### PR TITLE
allow opening of files in webview

### DIFF
--- a/app/lib/utils/url-command.js
+++ b/app/lib/utils/url-command.js
@@ -4,47 +4,23 @@ export const domainRegex = /\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)
 
 export default function isUrlCommand (shell, data) {
   const matcher = regex[shell];
-  if (undefined === matcher) return null;
-  let url, i;
+  if (undefined === matcher || !data) return null;
 
-  switch (matcher) {
-    case regex.bash:
-      i = 5;
-      break;
+  const match = data.match(matcher);
+  if (!match) return null;
+  const protocol = match[1];
+  const path = match[2];
 
-    case regex.zsh:
-      i = 7;
-      break;
-
-    case regex.fish:
-      i = 4;
-      break;
-  }
-
-  let match = data.match(matcher);
-
-  if (match) {
-    url = match[i];
-    if (url) {
-      // extract the domain portion from the url
-      const domain = url.split('/')[0];
-      if (domainRegex.test(domain)) {
-        return toURL(url);
-      }
+  if (path) {
+    if (protocol) {
+      return `${protocol}${path}`;
+    }
+    // extract the domain portion from the url
+    const domain = path.split('/')[0];
+    if (domainRegex.test(domain)) {
+      return `http://${path}`;
     }
   }
 
   return null;
-}
-
-function toURL (domain) {
-  if (/^https?:\/\//.test(domain)) {
-    return domain;
-  }
-
-  if ('//' === domain.substr(0, 2)) {
-    return domain;
-  }
-
-  return 'http://' + domain;
 }

--- a/app/lib/utils/url-regex.js
+++ b/app/lib/utils/url-regex.js
@@ -1,4 +1,4 @@
-export const sh = /(ba)?sh: ((https?:\/\/)|(\/\/))?(.*): ((command not found)|(No such file or directory))/;
+export const sh = /(?:ba)?sh: ((?:https?:\/\/)|(?:file:\/\/)|(?:\/\/))?(.*): (?:(?:command not found)|(?:No such file or directory))/;
 export const bash = sh;
-export const zsh = /zsh: ((command not found)|(no such file or directory)): ((https?:\/\/)|(\/\/))?([^\n]+)/;
-export const fish = /fish: Unknown command '((https?:\/\/)|(\/\/))?([^']+)'/;
+export const zsh = /zsh: (?:(?:command not found)|(?:no such file or directory)): ((?:https?:\/\/)|(?:file:\/\/)|(?:\/\/))?([^\n]+)/;
+export const fish = /fish: Unknown command '((?:https?:\/\/)|(?:file:\/\/)|(?:\/\/))?([^']+)'/;


### PR DESCRIPTION
If a URL is entered as a command, that URL is loaded in a webview. This PR will allow the file protocol `file://` to also be considered as a URL. This will allow you to open images, videos, music and more right inside the webview.

By adding non-capturing groups to the `url-regex.js` file, this made the `url-command.js` simpler.

This also fixes #304 