### PR TITLE
Adds plugin hook for decorating the electron browser options

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,9 +46,8 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
   function createWindow (fn) {
     const cfg = plugins.getDecoratedConfig();
-    const opts = plugins.getDecoratedBrowserOptions();
 
-    const browserOptions = Object.assign({
+    const browserDefaults = {
       width: 540,
       height: 380,
       minHeight: 190,
@@ -61,7 +60,8 @@ app.on('ready', () => {
       // we only want to show when the prompt
       // is ready for user input
       show: process.env.HYPERTERM_DEBUG || isDev
-    }, opts);
+    };
+    const browserOptions = plugins.getDecoratedBrowserOptions(browserDefaults);
 
     const win = new BrowserWindow(browserOptions);
 

--- a/index.js
+++ b/index.js
@@ -46,8 +46,9 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
   function createWindow (fn) {
     const cfg = plugins.getDecoratedConfig();
+    const opts = plugins.getDecoratedBrowserOptions();
 
-    const win = new BrowserWindow({
+    const browserOptions = Object.assign({
       width: 540,
       height: 380,
       minHeight: 190,
@@ -60,7 +61,9 @@ app.on('ready', () => {
       // we only want to show when the prompt
       // is ready for user input
       show: process.env.HYPERTERM_DEBUG || isDev
-    });
+    }, opts);
+
+    const win = new BrowserWindow(browserOptions);
 
     windowSet.add(win);
     win.loadURL(url);

--- a/plugins.js
+++ b/plugins.js
@@ -312,8 +312,8 @@ exports.getDecoratedConfig = function () {
   return decorated;
 };
 
-exports.getDecoratedBrowserOptions = function () {
-  let decorated = {};
+exports.getDecoratedBrowserOptions = function (defaults) {
+  let decorated = defaults;
   modules.forEach((plugin) => {
     if (plugin.decorateBrowserOptions) {
       const res = plugin.decorateBrowserOptions(decorated);

--- a/plugins.js
+++ b/plugins.js
@@ -311,3 +311,19 @@ exports.getDecoratedConfig = function () {
   });
   return decorated;
 };
+
+exports.getDecoratedBrowserOptions = function () {
+  let decorated = {};
+  modules.forEach((plugin) => {
+    if (plugin.decorateBrowserOptions) {
+      const res = plugin.decorateBrowserOptions(decorated);
+      if (res && 'object' === typeof res) {
+        decorated = res;
+      } else {
+        notify('Plugin error!', `"${plugin._name}": invalid return type for \`decorateBrowserOptions\``);
+      }
+    }
+  });
+  return decorated;
+};
+


### PR DESCRIPTION
Creates a new plugin hook `decorateBrowserOptions` as discussed in #232. It works just like `decorateConfig` but for the browser options that Electron expects in the [`BrowserWindow`][1] constructor.

Designed to be used [like this][2].

Default options are specified inline, but I guess they could be moved out like `config-default.js` if necessary.

[1]: https://github.com/electron/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions
[2]: https://github.com/danprince/hypertile/blob/master/index.js#L22-L25