### PR TITLE
Specify bash to run command in

### DIFF
--- a/app/lib/actions/ui.js
+++ b/app/lib/actions/ui.js
@@ -145,7 +145,7 @@ export function showPreferences () {
               uid,
               ['echo Attempting to open ~/.hyperterm.js with your \$EDITOR',
                'echo If it fails, open it manually with your favorite editor!',
-               'exec env $EDITOR ~/.hyperterm.js',
+               'bash -c "exec env $EDITOR ~/.hyperterm.js"',
                ''
               ].join('\n')
             ));


### PR DESCRIPTION
Could be useful for people who use a non-POSIX compatible shell, such as fish. I think it's common enough that this could be useful, and since it's Mac only, I think it's safe to say that the user has bash installed