### PR TITLE
Update dependencies

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "repository": "zeit/hyperterm",
   "dependencies": {
     "aphrodite-simple": "0.4.1",
-    "hterm-umdjs": "1.1.2",
+    "hterm-umdjs": "1.1.3",
     "json-loader": "0.5.4",
     "mousetrap": "1.6.0",
     "ms": "0.7.1",
@@ -24,15 +24,15 @@
   "devDependencies": {
     "babel-cli": "6.10.1",
     "babel-core": "6.10.4",
-    "babel-eslint": "6.1.1",
+    "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",
-    "babel-preset-es2015-native-modules": "6.6.0",
+    "babel-preset-es2015-native-modules": "6.9.0",
     "babel-preset-react": "6.11.1",
-    "eslint": "3.0.1",
+    "eslint": "3.1.1",
     "eslint-config-standard": "5.3.5",
-    "eslint-plugin-promise": "1.3.2",
+    "eslint-plugin-promise": "2.0.0",
     "eslint-plugin-react": "5.2.2",
-    "eslint-plugin-standard": "1.3.2",
+    "eslint-plugin-standard": "2.0.0",
     "webpack": "2.1.0-beta.15"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "child_pty": "3.0.1",
     "convert-css-color-name-to-hex": "0.1.1",
     "default-shell": "1.0.1",
-    "electron-config": "0.2.0",
+    "electron-config": "0.2.1",
     "electron-is-dev": "0.1.1",
     "gaze": "1.1.0",
     "mkdirp": "0.5.1",
@@ -18,12 +18,13 @@
     "uid2": "0.0.3"
   },
   "devDependencies": {
-    "electron-packager": "7.1.0",
-    "electron-prebuilt": "1.2.5",
-    "eslint": "2.13.1",
-    "eslint-config-standard": "5.3.1",
-    "eslint-plugin-promise": "1.3.2",
-    "eslint-plugin-standard": "1.3.2"
+    "electron-packager": "7.3.0",
+    "electron-prebuilt": "1.2.7",
+    "eslint": "3.1.1",
+    "eslint-config-standard": "5.3.5",
+    "eslint-plugin-promise": "2.0.0",
+    "eslint-plugin-react": "5.2.2",
+    "eslint-plugin-standard": "2.0.0"
   },
   "eslintConfig": {
     "extends": "standard",


### PR DESCRIPTION
This PR updates most of the dependencies except for `child_pty`.

I added `eslint-plugin-react` to the root package because otherwise eslint would sometimes complain about not being able to find the plugin when running it manually.

On my system, building with `child_pty` using version `v3.0.3` or `v3.0.4` caused `CTRL-C` to stop working. However, `CTRL-C` does work properly again if you build from master. Since [Gottox/child_pty@f416b22](https://github.com/Gottox/child_pty/commit/f416b22a3a004b036316c6708c878115bf7117d1) is the only post-`v3.0.4` commit, it appears that some termios flags (probably `ISIG`, maybe others) are not being set properly.

I did try to fix that by calling `setattr` after the pty is created with `child_pty.spawn()` in `session.js` but still couldn't get it to work. In any case, the termios stuff has been removed after `v3.0.4` so it's probably not worth bothering with.

