### PR TITLE
Move window close button into shell submenu

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -87,6 +87,11 @@ module.exports = function createMenu ({ createWindow, updatePlugins }) {
               focusedWindow.rpc.emit('session close req');
             }
           }
+        },
+        {
+          label: 'Close Terminal Window',
+          role: 'close',
+          accelerator: 'CmdOrCtrl+Shift+W',
         }
       ]
     },
@@ -207,9 +212,6 @@ module.exports = function createMenu ({ createWindow, updatePlugins }) {
       submenu: [
         {
           role: 'minimize'
-        },
-        {
-          role: 'close'
         },
         {
           type: 'separator'


### PR DESCRIPTION
IMO actions that affect a session don't belong into the window menu.
That's also how iTerm handles it.