### PR TITLE
Disable pinch-zoom functionality

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -15,6 +15,10 @@ import * as sessionActions from './actions/sessions';
 import { createStore, applyMiddleware } from 'redux';
 import HyperTermContainer from './containers/hyperterm';
 import { loadConfig, reloadConfig } from './actions/config';
+import { webFrame } from 'electron';
+
+// Disable pinch zoom
+webFrame.setZoomLevelLimits(1, 1);
 
 const store_ = createStore(
   rootReducer,


### PR DESCRIPTION
This fixes #156

We don't have yet a specific config file/location for the renderer.
Should I keep it in the index.js file?