### PR TITLE
Use node6 es2015 features; remove extra transforms

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,6 @@
     "babel-core": "6.10.4",
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",
-    "babel-preset-es2015-native-modules": "6.9.0",
     "babel-preset-react": "6.11.1",
     "eslint": "3.1.1",
     "eslint-config-standard": "5.3.5",
@@ -66,7 +65,6 @@
   },
   "babel": {
     "presets": [
-      "es2015-native-modules",
       "react"
     ]
   },

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ const isDev = require('electron-is-dev');
 const AutoUpdater = require('./auto-updater');
 const toHex = require('convert-css-color-name-to-hex');
 
+// --harmony enables a few remaining es2015 features not defaulted in node 6
+app.commandLine.appendSwitch('js-flags', '--harmony');
+
 // set up config
 const config = require('./config');
 config.init();


### PR DESCRIPTION
This PR removes some unnecessary babel transforms. Since the current electron ships with node 6 it already supports over 95% of the es2015 features out of the box (details [here](http://node.green/) and [here](https://kangax.github.io/compat-table/es6/)).

I've added the `--harmony` flag in the app to enable a few of the remaining non-defaulted es2015 features in node 6 (mostly related to `Function.name` and `Symbol`). But if you'd rather not use `--harmony` for some reason it probably won't hurt since these last few features are rarely used.