### PR TITLE
Hook scripts

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -73,6 +73,7 @@
   "scripts": {
     "dev": "webpack --watch",
     "lint": "eslint .",
-    "build": "NODE_ENV=production webpack"
+    "build": "NODE_ENV=production webpack",
+    "test": "npm run lint"
   }
 }

--- a/menu.js
+++ b/menu.js
@@ -91,7 +91,7 @@ module.exports = function createMenu ({ createWindow, updatePlugins }) {
         {
           label: 'Close Terminal Window',
           role: 'close',
-          accelerator: 'CmdOrCtrl+Shift+W',
+          accelerator: 'CmdOrCtrl+Shift+W'
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "eslint-config-standard": "5.3.5",
     "eslint-plugin-promise": "2.0.0",
     "eslint-plugin-react": "5.2.2",
-    "eslint-plugin-standard": "2.0.0"
+    "eslint-plugin-standard": "2.0.0",
+    "husky": "0.11.4"
   },
   "eslintConfig": {
     "extends": "standard",
@@ -47,6 +48,9 @@
   },
   "scripts": {
     "start": "electron index",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prepublish": "npm test",
+    "prepush": "npm test",
+    "test": "npm run lint"
   }
 }


### PR DESCRIPTION
This PR does the following:

- Add `husky` as a development dependency
- Set hook scripts for `prepush` and `prepublish` to run `npm test`
- Set `npm test` to at least call `npm run lint` for now
- Fix a linter issue in `menu.js`

The hook scripts for git (e.g., `prepush`) will be setup when the user runs `npm install`.

With the `prepush` hook, git will run `npm test` prior to pushing to a repo. Could also do `precommit` but it's overkill and can make complex rebase operations more difficult.