### PR TITLE
add `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` env vars

### DIFF
--- a/session.js
+++ b/session.js
@@ -2,7 +2,7 @@ const { app } = require('electron');
 const { EventEmitter } = require('events');
 const { exec } = require('child_process');
 const defaultShell = require('default-shell');
-const { productName, version } = require('../package');
+const { productName, version } = require('./package');
 
 let spawn;
 try {

--- a/session.js
+++ b/session.js
@@ -2,6 +2,7 @@ const { app } = require('electron');
 const { EventEmitter } = require('events');
 const { exec } = require('child_process');
 const defaultShell = require('default-shell');
+const { productName, version } = require('../package');
 
 let spawn;
 try {
@@ -27,7 +28,9 @@ module.exports = class Session extends EventEmitter {
       cwd,
       env: Object.assign({}, process.env, {
         LANG: app.getLocale(),
-        TERM: 'xterm-256color'
+        TERM: 'xterm-256color',
+        TERM_PROGRAM: productName,
+        TERM_PROGRAM_VERSION: version
       })
     });
 


### PR DESCRIPTION
MacOS's Terminal.app sets these same env variables.
They're useful to be able to sniff out the type of
terminal emulator and do different settings in your
bashrc / vimrc / etc. configuration files.

So for example, `TERM_PROGRAM` will be "HyperTerm",
and `TERM_PROGRAM_VERSION` will be the value from `package.json/version`.