### PR TITLE
Added cask update instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For downloads, documentation and the developer API head to: https://hyperterm.or
 (NOTE: only on macOS) With [Homebrew](http://brew.sh/) and [Homebrew Cask](https://caskroom.github.io/) installed, you can run this command:
 
 ```bash
+$ brew cask update
 $ brew cask install hyperterm
 ```
 


### PR DESCRIPTION
I setup cask loong time ago and hadn't updated cask since then. Had to update cask before I was able to install hyperterm. Also not the first one to encounter this: https://github.com/zeit/hyperterm/issues/295 :)