### PR TITLE
Make the cursor opaque by default so that the text beneath it remains legible

### DIFF
--- a/app/lib/components/term.js
+++ b/app/lib/components/term.js
@@ -138,6 +138,9 @@ export default class Term extends Component {
       .cursor-node[focus="false"] {
         border-width: 1px !important;
       }
+      .cursor-node[focus="true"] {
+        opacity: 0.5 !important;
+      }
       ${css}
     `]);
     return URL.createObjectURL(blob, { type: 'text/css' });


### PR DESCRIPTION
I've also made a POC implementation as HyperTerm theme: https://github.com/jamox/opaque-cursor but I feel this would make it a sensible default as well.
 
Before: 
![Before](https://cloud.githubusercontent.com/assets/1354151/17058141/5ebe7446-5027-11e6-82a7-8eae8bf8a740.jpg)

After:
![screen shot 2016-07-22 at 16 15 29](https://cloud.githubusercontent.com/assets/1354151/17058173/8c121a74-5027-11e6-8688-0d6190198bbf.jpg)
