### PR TITLE
Fix OS X keybindings

### DIFF
--- a/app/lib/containers/hyperterm.js
+++ b/app/lib/containers/hyperterm.js
@@ -4,7 +4,7 @@ import TermsContainer from './terms';
 import NotificationsContainer from './notifications';
 import Component from '../component';
 import Mousetrap from 'mousetrap';
-import { moveTo, moveLeft, moveRight } from '../actions/ui';
+import * as uiActions from '../actions/ui';
 import { connect } from '../utils/plugins';
 
 const isMac = /Mac/.test(navigator.userAgent);
@@ -132,15 +132,15 @@ const HyperTermContainer = connect(
   (dispatch) => {
     return {
       moveTo: (i) => {
-        dispatch(moveTo(i));
+        dispatch(uiActions.moveTo(i));
       },
 
       moveLeft: () => {
-        dispatch(moveLeft());
+        dispatch(uiActions.moveLeft());
       },
 
       moveRight: () => {
-        dispatch(moveRight());
+        dispatch(uiActions.moveRight());
       }
     };
   },


### PR DESCRIPTION
For some strange reason it seems like the imported UI action creators were overriding the mapped props with the same names (`moveTo` etc.), [here](https://github.com/zeit/hyperterm/blob/d47e9e43d64ca5300e0df667625ab17a4f703044/app/lib/containers/hyperterm.js#L32). 

This used to work flawlessly previously, so kind of confusing. Would love if someone would try reproducing so it's not just me doing something weird (Node 6.2.0, OS X 10.11.5).