### PR TITLE
fix shell property value

### DIFF
--- a/session.js
+++ b/session.js
@@ -45,7 +45,7 @@ module.exports = class Session extends EventEmitter {
       }
     });
 
-    this.shell = defaultShell;
+    this.shell = shell || defaultShell;
     this.getTitle();
   }
 


### PR DESCRIPTION
When using the new shell option from #192, the `shell` prop is not correctly being set on the session object. This will correctly set the prop.