### PR TITLE
Check if session exists before exiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ app.on('ready', () => {
 
     rpc.on('exit', ({ uid }) => {
       const session = sessions.get(uid);
-      session ? session.exit() : false;
+      session && session.exit();
     });
 
     rpc.on('unmaximize', () => {

--- a/index.js
+++ b/index.js
@@ -141,7 +141,8 @@ app.on('ready', () => {
     });
 
     rpc.on('exit', ({ uid }) => {
-      sessions.get(uid).exit();
+      const session = sessions.get(uid);
+      session ? session.exit() : false;
     });
 
     rpc.on('unmaximize', () => {


### PR DESCRIPTION
As talked about on the zeit slack channel. When all windows are closed and you press `cmd + w` you get the following error:
<img width="532" alt="screen shot 2016-07-24 at 09 56 49" src="https://cloud.githubusercontent.com/assets/6324199/17082597/0236aff4-5185-11e6-9216-5e2a1a003029.png">

This extra check to see if the session is still there fixes it.