### PR TITLE
Allow for specifying global hotkey for toggling visibility

### DIFF
--- a/@hyperterm/hotkey/LICENSE.md
+++ b/@hyperterm/hotkey/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Cameron Spear
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/@hyperterm/hotkey/hotkey.js
+++ b/@hyperterm/hotkey/hotkey.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const electron = require('electron');
+const remove = require('lodash.remove');
+const { globalShortcut } = electron;
+
+module.exports = class Hotkey {
+  constructor () {
+    this.windows = [];
+    this.config = {};
+  }
+
+  setConfig (config = {}) {
+    this.unregisterGlobalHotkey();
+    this.config = config;
+    this.registerGlobalHotkey();
+  }
+
+  registerGlobalHotkey () {
+    if (typeof this.config.hotkey !== 'string') return;
+
+    globalShortcut.register(this.config.hotkey, () => this.toggleWindow());
+  }
+
+  unregisterGlobalHotkey () {
+    if (typeof this.config.hotkey !== 'string') return;
+
+    globalShortcut.unregister(this.config.hotkey);
+  }
+
+  toggleWindow () {
+    let allHidden = true;
+
+    for (let i = 0; i < this.windows.length; i++) {
+      if (this.windows[i].isVisible()) {
+        allHidden = false;
+      }
+    }
+
+    // We disable focus detection when programatically transitioning
+    this.transitioning = true;
+
+    for (let i = 0; i < this.windows.length; i++) {
+      if (allHidden) {
+        this.windows[i].show();
+
+        if (i === this.windows.length - 1) {
+          this.windows[i].focus();
+        }
+      } else {
+        this.windows[i].hide();
+      }
+    }
+
+    this.transitioning = false;
+  }
+
+  registerWindow (win) {
+    const onClose = () => {
+      remove(this.windows, { id: win.id });
+    };
+
+    const onFocus = () => {
+      // Ignore focus event when programmatically showing / hiding
+      if (!this.transitioning) {
+        // Move focused window on top of the stack
+        remove(this.windows, { id: win.id });
+        this.windows.push(win);
+      }
+    };
+
+    win.on('close', onClose);
+    win.on('focus', onFocus);
+
+    this.windows.push(win);
+  }
+
+  destroy () {
+    this.unregisterGlobalHotkey();
+  }
+};

--- a/@hyperterm/hotkey/index.js
+++ b/@hyperterm/hotkey/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const Hotkey = require('./hotkey');
+
+let hotkey = new Hotkey();
+
+module.exports.onWindow = function handleNewVisorWindow (win) {
+  hotkey.registerWindow(win);
+};
+
+module.exports.onApp = function registerGlobalHotkey (app) {
+  hotkey.setConfig(app.config.getConfig() || {});
+};
+
+module.exports.onUnload = function unregisterGlobalHotkey () {
+  hotkey.destroy();
+};

--- a/@hyperterm/hotkey/package.json
+++ b/@hyperterm/hotkey/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@hyperterm/hotkey",
+  "version": "1.0.0",
+  "description": "Open HyperTerm terminal with a global hotkey.",
+  "repository": "",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "electron": "^0.4.1",
+    "lodash.remove": "^4.5.0"
+  },
+  "keywords": [
+    "hyperterm",
+    "hyperterm-plugin"
+  ]
+}

--- a/config-default.js
+++ b/config-default.js
@@ -54,7 +54,11 @@ module.exports = {
 
     // the shell to run when spawning a new session (i.e. /usr/local/bin/fish)
     // if left empty, your system's login shell will be used by default
-    shell: ''
+    shell: '',
+
+    // global hotkey to toggle window visibility. for list of available hotkeys, see:
+    // https://github.com/electron/electron/blob/master/docs/api/accelerator.md
+    hotkey: 'F12'
 
     // for advanced config flags please refer to https://hyperterm.org/#cfg
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "mkdirp": "0.5.1",
     "ms": "0.7.1",
     "shell-env": "0.1.2",
-    "uid2": "0.0.3"
+    "uid2": "0.0.3",
+    "@hyperterm/hotkey": "file:@hyperterm/hotkey"
   },
   "devDependencies": {
     "electron-installer-debian": "0.3.0",

--- a/plugins.js
+++ b/plugins.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const { app, dialog } = require('electron');
 const { homedir } = require('os');
 const { resolve, basename } = require('path');
@@ -215,6 +216,9 @@ exports.subscribe = function (fn) {
 
 function getPaths () {
   return {
+    defaultPlugins: fs.readdirSync(resolve(__dirname, '@hyperterm')).map((name) => {
+      return resolve(__dirname, '@hyperterm', name);
+    }),
     plugins: plugins.plugins.map((name) => {
       return resolve(path, 'node_modules', name.split('#')[0]);
     }),
@@ -233,7 +237,7 @@ exports.getBasePaths = function () {
 };
 
 function requirePlugins () {
-  const { plugins, localPlugins } = paths;
+  const { defaultPlugins, plugins, localPlugins } = paths;
 
   const load = (path) => {
     let mod;
@@ -261,8 +265,8 @@ function requirePlugins () {
     }
   };
 
-  return plugins.map(load)
-    .concat(localPlugins.map(load))
+  return defaultPlugins.concat(plugins).concat(localPlugins)
+    .map(load)
     .filter(v => !!v);
 }
 


### PR DESCRIPTION
I've implemented it as a default plugin for hyperterm. My presented suggestion is to put default hyperterm plugins into `@hyperterm` folder and namespace modules with `@hyperterm` scope. You might consider claiming this scope on npm.

As for hotkey behavior, it is the same as in iTerm2:

- If any window is hidden, show all
- If all windows are shown, hide all
- Preserve focused window and z-order when showing / hidding them.

The hotkey is configurable with "hotkey" option.