### PR TITLE
plugins: fix wrong require path

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -201,7 +201,7 @@ function install (fn) {
     let registry = exports.getDecoratedConfig().npmRegistry;
     if (registry) env.NPM_CONFIG_REGISTRY = registry;
     env.npm_config_runtime = 'electron';
-    env.npm_config_target = require('./package.json').devDependencies['electron-prebuilt'];
+    env.npm_config_target = require('../package.json').devDependencies['electron-prebuilt'];
     env.npm_config_disturl = 'https://atom.io/download/atom-shell';
     exec('npm prune && npm install --ignore-scripts --production', {
       cwd: path,


### PR DESCRIPTION
Seems like the path wasn't updated when stuff was moved around 😀