### PR TITLE
Updated README.md to use npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ npm run dev
 and to load the application simply run:
 
 ```
-electron app/index.js
+npm start
 ```


### PR DESCRIPTION
Updated README.md to use npm scripts in favor of always running the same version of electron while developing.