### PR TITLE
Adjust eslint configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,6 @@
+app/dist
+app/node_modules
+app/static
+assets
+build
 dist

--- a/app/.eslintignore
+++ b/app/.eslintignore
@@ -1,2 +1,0 @@
-dist
-node_modules

--- a/package.json
+++ b/package.json
@@ -48,22 +48,22 @@
       "react"
     ],
     "rules": {
-      "yoda": 0,
+      "yoda": "off",
       "semi": [
-        2,
+        "error",
         "always"
       ],
-      "no-unused-vars": 2,
-      "no-extra-semi": 2,
+      "no-unused-vars": "error",
+      "no-extra-semi": "error",
       "semi-spacing": [
-        2,
+        "error",
         {
           "before": false,
           "after": true
         }
       ],
-      "react/jsx-uses-react": 1,
-      "react/jsx-uses-vars": 1
+      "react/jsx-uses-react": "warn",
+      "react/jsx-uses-vars": "warn"
     },
     "parserOptions": {
       "ecmaFeatures": {
@@ -88,7 +88,7 @@
   },
   "scripts": {
     "dev": "webpack --watch",
-    "lint": "eslint lib/ && eslint app/*.js",
+    "lint": "eslint .",
     "build": "NODE_ENV=production webpack",
     "test": "npm run lint",
     "start": "electron app",


### PR DESCRIPTION
This PR makes some small adjustments to the `eslint` configuration to run a little faster.

@rauchg the updated `npm run lint` script with `eslint lib/ && eslint app/*.js` actually runs a bit slower because `eslint` is being invoked twice. You could change it to `eslint lib/ app/*.js` if you want to explicit specify the included files. Here are some quick tests:

```
$ time npm run lint

> hyperterm-web@0.0.1 lint ~/github/hyperterm
> eslint lib/ && eslint app/*.js

npm run lint  3.21s user 0.25s system 115% cpu 2.989 total
```

```
time npm run lint

> hyperterm-web@0.0.1 lint ~/github/hyperterm
> eslint .

npm run lint  2.37s user 0.18s system 114% cpu 2.221 total
```

```
$ time npm run lint

> hyperterm-web@0.0.1 lint ~/github/hyperterm
> eslint lib app/*.js

npm run lint  2.23s user 0.16s system 115% cpu 2.069 total
```

I prefer using `eslint .` though because it will automatically check new (sub)directories that get added without having to remember to update the script. But either way, I think it's a good idea to explicitly list all of the necessary excludes in the `.eslintignore` file because that will allow the user to run `eslint` manually. I have some custom scripts I use with `eslint` so it's nice to have this.

I've also removed `app/.eslintignore` and the `eslintConfig` property from `package.json` since they are no longer necessary (and also because `eslint` is no longer installed there in the dev dependencies).