### PR TITLE
Only try to match url if it's needed

### DIFF
--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -58,8 +58,11 @@ export function addSessionData (uid, data) {
       data,
       effect () {
         const { shell } = getState().sessions.sessions[uid];
-        const url = getURL(shell, data);
-        if (null !== url) {
+
+        const enterKey = Boolean(data.match(/\n/));
+        const url = enterKey ? getURL(shell, data) : null;
+
+        if (url) {
           dispatch({
             type: SESSION_URL_SET,
             uid,


### PR DESCRIPTION
- Only try to match an URL when the enter key is sent

Maybe there's some better way to check when a command is being run, but before this the getURL function was called on every keypress