### PR TITLE
Update pkg metadata; try to fix linux travis build

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,11 @@
   "productName": "HyperTerm",
   "version": "0.7.0",
   "license": "MIT",
-  "author": "rauchg",
+  "author": {
+    "name": "Guillermo Rauch",
+    "email": "rauchg@users.noreply.github.com",
+    "url": "https://github.com/rauchg"
+  },
   "repository": "zeit/hyperterm",
   "description": "HTML/JS/CSS Terminal",
   "dependencies": {


### PR DESCRIPTION
This PR adds some missing author metadata that is causing the linux travis build to fail. See #390.