### PR TITLE
Warn before quitting with sessions open

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, shell, Menu } = require('electron');
+const { app, BrowserWindow, shell, Menu, dialog } = require('electron');
 const createRPC = require('./rpc');
 const createMenu = require('./menu');
 const uuid = require('uuid');
@@ -36,6 +36,29 @@ console.log('electron will open', url);
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
+  }
+});
+
+let quitIsConfirmed = false;
+
+app.on('before-quit', (event) => {
+  const windows = BrowserWindow.getAllWindows().filter(win => win.sessions);
+
+  if (!quitIsConfirmed && Boolean(windows.length)) {
+    event.preventDefault();
+
+    dialog.showMessageBox({
+      type: 'question',
+      buttons: ['OK', 'Cancel'],
+      defaultId: 0,
+      title: 'Quit HyperTerm?',
+      message: 'All sessions will be closed.'
+    }, (index) => {
+      if (index === 0) {
+        quitIsConfirmed = true;
+        app.quit();
+      }
+    });
   }
 });
 


### PR DESCRIPTION
Fixes #399, #67

Im putting this up here to discuss if we should put an option in the menu like chrome  
![image](https://cloud.githubusercontent.com/assets/5027156/17116914/331f3b82-52ba-11e6-9193-77ef788ab226.png)

Or if we just should just have a config option for it in `hyperterm.js`

If we want to have it so that the checkbox changes your settings, we need to do like [hpm](https://github.com/matheuss/hpm/blob/master/hyperterm.js) to read and change hyperterm.js

However, with that approach there can be 🐎 race conditions, so i think we should wait with that. 
