### PR TITLE
Handle lost session on rpc data

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -159,7 +159,13 @@ app.on('ready', () => {
     });
 
     rpc.on('data', ({ uid, data }) => {
-      sessions.get(uid).write(data);
+      const session = sessions.get(uid);
+
+      if (session) {
+        session.write(data);
+      } else {
+        console.log('session not found by', uid);
+      }
     });
 
     rpc.on('open external', ({ url }) => {


### PR DESCRIPTION
Solves #401, check if the session exists like when running `exit`

However, i think there's something that's not done correctly when closing tabs that makes this happen, will investigate more. Possibly race-condition?

If you open a couple of tabs and then close them all quickly it logs `session not found by` from `rpc.on('exit')..`, maybe the close is happening more than once if you do it fast, before it actually got time to close.