### PR TITLE
Update shell after config change and notify the user

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -6,6 +6,7 @@ const { resolve } = require('path');
 const isDev = require('electron-is-dev');
 const AutoUpdater = require('./auto-updater');
 const toHex = require('convert-css-color-name-to-hex');
+const notify = require('./notify');
 
 // set up config
 const config = require('./config');
@@ -41,7 +42,8 @@ app.on('window-all-closed', () => {
 
 app.on('ready', () => {
   function createWindow (fn) {
-    const cfg = plugins.getDecoratedConfig();
+    let cfg = plugins.getDecoratedConfig();
+
     const [width, height] = cfg.windowSize || [540, 380];
 
     const browserDefaults = {
@@ -70,7 +72,18 @@ app.on('ready', () => {
 
     // config changes
     const cfgUnsubscribe = config.subscribe(() => {
+      const cfg_ = plugins.getDecoratedConfig();
+
       win.webContents.send('config change');
+
+      if (cfg_.shell !== cfg.shell) {
+        notify(
+          'Shell configuration changed!',
+          'Open a new tab or window to start using the new shell'
+        );
+      }
+
+      cfg = cfg_;
     });
 
     rpc.on('init', () => {


### PR DESCRIPTION
Currently, if you update the shell, it does not take effect until a full reload. This updated the config when it changes, which will update the shell on a new session.

This also sends the user a notification to open a new tab or window to see the shell change.