### PR TITLE
Add a slight timeout to update the fontSmoothing pref

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -60,14 +60,18 @@ export function resetFontSize () {
 }
 
 export function setFontSmoothing () {
-  const devicePixelRatio = window.devicePixelRatio;
-  const fontSmoothing = devicePixelRatio < 2
-    ? 'subpixel-antialiased'
-    : 'antialiased';
+  return (dispatch) => {
+    setTimeout(() => {
+      const devicePixelRatio = window.devicePixelRatio;
+      const fontSmoothing = devicePixelRatio < 2
+        ? 'subpixel-antialiased'
+        : 'antialiased';
 
-  return {
-    type: UI_FONT_SMOOTHING_SET,
-    fontSmoothing
+      dispatch({
+        type: UI_FONT_SMOOTHING_SET,
+        fontSmoothing
+      });
+    }, 100);
   };
 }
 


### PR DESCRIPTION
This seems like a bug with chrome/electron where the devicePixelRatio
value doesn't update right away. It's probably in the event loop, so
adding a short timeout should solve this problem.