### PR TITLE
Fixed path to the close tab icon.

### DIFF
--- a/lib/components/tab.js
+++ b/lib/components/tab.js
@@ -65,7 +65,7 @@ export default class Tab extends Component {
           ) }
           onClick={ this.props.onClose }>
           <svg className={ css('shape') }>
-            <use xlinkHref='assets/icons.svg#close'></use>
+            <use xlinkHref='../assets/icons.svg#close'></use>
           </svg>
         </i>
         { this.props.customChildren }


### PR DESCRIPTION
Hey, 

This PR fixes a problem I noticed in the latest release (0.7.1), the close tab icon doesn't show up, there's only a gray circle with the cross missing, and the console log shows: 

```
GET file:///Applications/HyperTerm.app/Contents/Resources/app/assets/icons.svg net::ERR_FILE_NOT_FOUND
```

It seems like it was copied to the build path before using the old `package.sh` script (https://github.com/zeit/hyperterm/commit/7953c886a825fa7fbf470a285c8d8ca43d4769eb), should we do something like that instead? 

Please check it out, thanks! 