### PR TITLE
Use babel for minification

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,6 +8,8 @@ const AutoUpdater = require('./auto-updater');
 const toHex = require('convert-css-color-name-to-hex');
 const notify = require('./notify');
 
+app.commandLine.appendSwitch('js-flags', '--harmony');
+
 // set up config
 const config = require('./config');
 config.init();

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "babel-core": "6.11.4",
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",
-    "babel-preset-es2015-native-modules": "6.9.2",
     "babel-preset-react": "6.11.1",
     "electron-builder": "5.17.0",
     "electron-prebuilt": "1.3.1",
@@ -76,7 +75,6 @@
   },
   "babel": {
     "presets": [
-      "es2015-native-modules",
       "react"
     ]
   },
@@ -101,7 +99,7 @@
     "prepublish": "npm test",
     "prepush": "npm test",
     "postinstall": "install-app-deps",
-    "pack": "npm run build && build --dir",
+    "pack": "npm run build && build --dir && babel --no-comments --compact --minified --out-file app/dist/bundle.js app/dist/bundle.js",
     "dist": "npm run build && build",
     "release": "npm run build && build --publish=onTagOrDraft"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,9 +16,7 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
-        loaders: [
-          'babel-loader'
-        ]
+        loader: 'babel'
       },
       {
         test: /\.json/,
@@ -27,27 +25,11 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.ExternalsPlugin('commonjs', ['electron']),
-    new webpack.optimize.UglifyJsPlugin({
-      mangle: {
-        keep_fnames: true
-      },
-      compress: {
-        warnings: false
-      },
-      output: {
-        comments: false
-      },
-      sourceMap: false
-    }),
-    new webpack.LoaderOptionsPlugin({
-      minimize: true,
-      debug: false
-    }),
     new webpack.DefinePlugin({
       'process.env': {
         'NODE_ENV': JSON.stringify(nodeEnv)
       }
     })
-  ]
+  ],
+  target: 'electron'
 };


### PR DESCRIPTION
This PR does the following:

1. Remove UglifyJS
2. Simplify webpack settings
3. Run `app/dist/bundle.js` through `babel` with minification options
4. Enable harmony flags

The result of (3) is that `bundle.js` is stripped of comments, whitespace, etc.

Size of `bundle.js`:
```
uglify: 528K
babel: 784K
```

The `babel` configuration doesn't do name mangling so it's not as aggressive as uglify but there are a number of transformations that could be applied that might make up some of the difference. See [here](https://github.com/boopathi/babel-minify). Still, minifying with basic `babel` options is not bad.

On my system, init seems to be around `10ms` slower on average. Again, some of the other transforms might make up the difference. It would be nice if someone else could confirm this.

@rauchg I tried using the `harmony` branch for uglify and enabling the babel `es2015` transforms individually but it seems like it only has very basic support for es6 still so it's not worth bothering with. I think it's better to move away from uglify in the long run because it seems unlikely they'll have es6 support any time soon. It sounds like the babel developers are working on a babel-based solution which will probably be the best bet.