### PR TITLE
Preventing shell history pollution with prefs edit commands

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -147,9 +147,9 @@ export function showPreferences () {
           rpc.once('session data', () => {
             dispatch(sendSessionData(
               uid,
-              ['echo Attempting to open ~/.hyperterm.js with your \$EDITOR', // eslint-disable-line no-useless-escape
-               'echo If it fails, open it manually with your favorite editor!',
-               'bash -c "exec env $EDITOR ~/.hyperterm.js"',
+              [' echo Attempting to open ~/.hyperterm.js with your \$EDITOR', // eslint-disable-line no-useless-escape
+               ' echo If it fails, open it manually with your favorite editor!',
+               ' bash -c "exec env $EDITOR ~/.hyperterm.js"',
                ''
               ].join('\n')
             ));


### PR DESCRIPTION
Issue (using zsh) : 
````
$ history
 1824  2016-07-28 12:27  npm run start
 1825  2016-07-28 12:27  echo Attempting to open ~/.hyperterm.js with your $EDITOR
 1826  2016-07-28 12:27  echo If it fails, open it manually with your favorite editor!
 1827  2016-07-28 12:27  bash -c "exec env $EDITOR ~/.hyperterm.js"
````
Adding a space before commands prevent history storing on modern shell.
