### PR TITLE
Revert "Fix Close process  (#450)"; fix #467

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -227,9 +227,6 @@ app.on('ready', () => {
       deleteSessions();
       cfgUnsubscribe();
       pluginsUnsubscribe();
-      if (windowSet.size === 0) {
-        win.close();
-      }
     });
   }
 


### PR DESCRIPTION
This reverts commit 72059a7d93f7d18456f8bdf4efcc9ad6c0a084d8.

I talked with others on slack who were seeing master crash after #450. `win.close` should not be called again within `win.on('close', …)`. This causes a crash on close (#467), at least on OS X.

According to the [electron docs](https://github.com/electron/electron/blob/master/docs/api/app.md#app), the correct way to close the app after all windows have been closed is as follows:

```
app.on('window-all-closed', () => {
  app.quit()
})
```

However, that is already in place [here](https://github.com/freebroccolo/hyperterm/blob/89d5da48d0844d9c85d78742dc2f8e90e6edd37a/app/index.js#L39-L43), specifically with a platform guard.

So if there is an issue with the app not closing on Linux (#206) it is probably something else causing it. Maybe an electron bug or a bug with the WM or something else.