### PR TITLE
changed regex for most forms of localhost

### DIFF
--- a/lib/utils/url-command.js
+++ b/lib/utils/url-command.js
@@ -1,6 +1,6 @@
 import * as regex from './url-regex';
 
-export const domainRegex = /\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b/;
+export const domainRegex = /\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b|^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*:)*?:?0*1$/;
 
 export default function isUrlCommand (shell, data) {
   const matcher = regex[shell];


### PR DESCRIPTION
This will allow users to open most forms of localhost using hyperterm.

I am new to regex and used this http://stackoverflow.com/questions/8426171/what-regex-will-match-all-loopback-addresses

Any feedback is much appreciated

Tested on OSX.
Fixes #98 