### PR TITLE
Fix #467 and #206; quit app on window close

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -36,12 +36,6 @@ const url = 'file://' + resolve(
 
 console.log('electron will open', url);
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
-});
-
 app.on('ready', () => {
   function createWindow (fn) {
     let cfg = plugins.getDecoratedConfig();
@@ -227,8 +221,11 @@ app.on('ready', () => {
       deleteSessions();
       cfgUnsubscribe();
       pluginsUnsubscribe();
-      if (windowSet.size === 0) {
-        win.close();
+    });
+
+    win.on('closed', () => {
+      if (process.platform !== 'darwin') {
+        app.quit();
       }
     });
   }


### PR DESCRIPTION
This PR fixes the crash on close on OS X (#467) that was introduced by #450 but still fixes #206.

@rauchg @albinekb @c0b41 It seems the problem was that the `window-all-closed` event was never being triggered. (I looked through the electron issues and didn't see anything about that so I'm not sure if it's just the current behavior or something wrong on our end.)

I've tested this on OS X `10.11.6` and on Ubuntu `16.04`. The only events triggered on window close are `close` and `closed`. Calling `app.quit()` on `closed` seems to work fine.