### PR TITLE
Prevent hovering on tabs from causing text flicker

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -15,6 +15,12 @@
         text-rendering: optimizeLegibility;
         box-sizing: border-box;
       }
+
+      @media (min-resolution: 2dppx) {
+        * {
+          text-rendering: geometricPrecision;
+        }
+      }
     </style>
   </head>
 

--- a/app/index.html
+++ b/app/index.html
@@ -12,7 +12,7 @@
       * {
         margin: 0;
         padding: 0;
-        text-rendering: geometricPrecision;
+        text-rendering: optimizeLegibility;
         box-sizing: border-box;
       }
     </style>


### PR DESCRIPTION
For some reason, geometricPrecision was causing text to flicker on non-retina screens when hovering over the tabs. Fixes #436 