### PR TITLE
Correct css blob type

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -139,8 +139,8 @@ export default class Term extends Component {
         border-width: 1px !important;
       }
       ${css}
-    `]);
-    return URL.createObjectURL(blob, { type: 'text/css' });
+    `], { type: 'text/css' });
+    return URL.createObjectURL(blob);
   }
 
   componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
- Correctly copy assets (fix for https://github.com/zeit/hyperterm/commit/2a13f3a38f686131d479947e7a36e64ef1f2bd76)
- Use correct way to set blob type
#505 
🐱 