### PR TITLE
Fallback to nano if no editor is set

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -137,6 +137,11 @@ export function moveTo (i) {
 }
 
 export function showPreferences () {
+
+  var editorFallback = 'nano';
+  if (process.platform === 'win32') {
+    editorFallback = 'notepad';
+  }
   return (dispatch, getState) => {
     dispatch({
       type: UI_SHOW_PREFERENCES,
@@ -150,7 +155,7 @@ export function showPreferences () {
               // Leading space prevents command to be store in shell history
               [' echo Attempting to open ~/.hyperterm.js with your \$EDITOR', // eslint-disable-line no-useless-escape
                ' echo If it fails, open it manually with your favorite editor!',
-               ' bash -c "exec env ${EDITOR:=nano} ~/.hyperterm.js"',
+               ' bash -c "exec env ${EDITOR:=' + editorFallback + '} ~/.hyperterm.js"',
                ''
               ].join('\n')
             ));

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -150,7 +150,7 @@ export function showPreferences () {
               // Leading space prevents command to be store in shell history
               [' echo Attempting to open ~/.hyperterm.js with your \$EDITOR', // eslint-disable-line no-useless-escape
                ' echo If it fails, open it manually with your favorite editor!',
-               ' bash -c "exec env $EDITOR ~/.hyperterm.js"',
+               ' bash -c "exec env ${EDITOR:=nano} ~/.hyperterm.js"',
                ''
               ].join('\n')
             ));

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -137,10 +137,7 @@ export function moveTo (i) {
 }
 
 export function showPreferences () {
-  var editorFallback = 'nano';
-  if (process.platform === 'win32') {
-    editorFallback = 'notepad';
-  }
+  const editorFallback = process.platform === 'win32' ? 'notepad' : 'nano';
   return (dispatch, getState) => {
     dispatch({
       type: UI_SHOW_PREFERENCES,

--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -137,7 +137,6 @@ export function moveTo (i) {
 }
 
 export function showPreferences () {
-
   var editorFallback = 'nano';
   if (process.platform === 'win32') {
     editorFallback = 'notepad';


### PR DESCRIPTION
If $EDITOR is not set, changing the config file fails. We should default to nano. 

![screen shot 2016-07-30 at 14 35 30](https://cloud.githubusercontent.com/assets/47539/17270792/3ed5f748-5663-11e6-830b-744b8102461f.png)

Reasons to use nano:

* It's eveywhere.
* It's less confusing for beginners, the instructions for saving the file are at the bottom.
* Vim fans will have already set their $EDITOR config, or this will convince them to.
* crontab on a fresh Ubuntu install does the same thing, presumably for the reasons listed above.

I'm personally a vim fan, but this just fixes an issue new users a likely to run into.