### PR TITLE
Add support for opening the terminal on the correct display

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -44,7 +44,7 @@ app.on('ready', () => {
 
     let startX = 50;
     let startY = 50;
-    
+
     // Open the new window roughly the height of the header away from the
     // previous window. This also ensures in multi monitor setups that the
     // new terminal is on the correct screen.

--- a/app/index.js
+++ b/app/index.js
@@ -41,7 +41,7 @@ app.on('ready', () => {
     let cfg = plugins.getDecoratedConfig();
 
     const [width, height] = cfg.windowSize || [540, 380];
-    const { screen } = require('electron')
+    const { screen } = require('electron');
 
     let startX = 50;
     let startY = 50;

--- a/app/index.js
+++ b/app/index.js
@@ -42,6 +42,19 @@ app.on('ready', () => {
 
     const [width, height] = cfg.windowSize || [540, 380];
 
+    let startX = 50;
+    let startY = 50;
+    
+    // Open the new window roughly the height of the header away from the
+    // previous window. This also ensures in multi monitor setups that the
+    // new terminal is on the correct screen.
+    if (BrowserWindow.getFocusedWindow() !== null) {
+      const currentWindow = BrowserWindow.getFocusedWindow();
+      const points = currentWindow.getPosition();
+      startX = points[0] + 34;
+      startY = points[1] + 34;
+    }
+
     const browserDefaults = {
       width,
       height,
@@ -54,7 +67,9 @@ app.on('ready', () => {
       icon: resolve(__dirname, 'static/icon.png'),
       // we only want to show when the prompt
       // is ready for user input
-      show: process.env.HYPERTERM_DEBUG || isDev
+      show: process.env.HYPERTERM_DEBUG || isDev,
+      x: startX,
+      y: startY
     };
     const browserOptions = plugins.getDecoratedBrowserOptions(browserDefaults);
 

--- a/app/index.js
+++ b/app/index.js
@@ -41,6 +41,7 @@ app.on('ready', () => {
     let cfg = plugins.getDecoratedConfig();
 
     const [width, height] = cfg.windowSize || [540, 380];
+    const { screen } = require('electron')
 
     let startX = 50;
     let startY = 50;
@@ -51,8 +52,21 @@ app.on('ready', () => {
     if (BrowserWindow.getFocusedWindow() !== null) {
       const currentWindow = BrowserWindow.getFocusedWindow();
       const points = currentWindow.getPosition();
-      startX = points[0] + 34;
-      startY = points[1] + 34;
+      const currentScreen = screen.getDisplayNearestPoint({ x: points[0], y: points[1] });
+
+      const biggestX = ((points[0] + 100 + width) - currentScreen.bounds.x);
+      const biggestY = ((points[1] + 100 + height) - currentScreen.bounds.y);
+
+      if (biggestX > currentScreen.size.width) {
+        startX = 50;
+      } else {
+        startX = points[0] + 34;
+      }
+      if (biggestY > currentScreen.size.height) {
+        startY = 50;
+      } else {
+        startY = points[1] + 34;
+      }
     }
 
     const browserDefaults = {


### PR DESCRIPTION
See this issue https://github.com/zeit/hyperterm/issues/481

Opening a new window will now open it ever so slightly diagonally across from the current active window. This is the same behaviour as Terminal.app. I've got for the height of the header as the value.

<img width="1680" alt="screen shot 2016-07-30 at 17 46 20" src="https://cloud.githubusercontent.com/assets/47539/17271796/a5b329f8-567d-11e6-9371-ebeb8183ebfe.png">
