### PR TITLE
Initial support for pressing ~ ^ " ' ` on international keyboard layouts until composed characters lands

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -42,11 +42,11 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
     this.terminal.onVTKeystroke('"');
     return;
   }
-  if (e.key === 'Dead' && e.code === 'IntlBackslash' && e.shiftKey === true) {
+  if (e.key === 'Dead' && (e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === true) {
     this.terminal.onVTKeystroke('~');
     return;
   }
-  if (e.key === 'Dead' && e.code === 'IntlBackslash' && e.shiftKey === false) {
+  if (e.key === 'Dead' && (e.code === 'IntlBackslash' || e.code === 'Backquote') && e.shiftKey === false) {
     this.terminal.onVTKeystroke('`');
     return;
   }

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -43,7 +43,7 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
     return;
   }
   if (e.key === 'Dead' && e.code === 'IntlBackslash' && e.shiftKey === true) {
-    this.terminal.onVTKeystroke('˜');
+    this.terminal.onVTKeystroke('~');
     return;
   }
   if (e.key === 'Dead' && e.code === 'IntlBackslash' && e.shiftKey === false) {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -51,7 +51,7 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
     return;
   }
   if (e.key === 'Dead' && e.code === 'Digit6') {
-    this.terminal.onVTKeystroke('ˆ');
+    this.terminal.onVTKeystroke('^');
     return;
   }
   if (e.metaKey || e.altKey) {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -29,6 +29,31 @@ hterm.Terminal.prototype.copySelectionToClipboard = function () {
 // hyperterm and not the terminal itself
 const oldKeyDown = hterm.Keyboard.prototype.onKeyDown_;
 hterm.Keyboard.prototype.onKeyDown_ = function (e) {
+  /**
+   * Add fixes for U.S. International PC Keyboard layout
+   * These keys are sent through as 'Dead' keys, as they're used as modifiers.
+   * Ignore that and insert the correct character.
+   */
+  if (e.key === 'Dead' && e.code === 'Quote' && e.shiftKey === false) {
+    this.terminal.onVTKeystroke("'");
+    return;
+  }
+  if (e.key === 'Dead' && e.code === 'Quote' && e.shiftKey === true) {
+    this.terminal.onVTKeystroke('"');
+    return;
+  }
+  if (e.key === 'Dead' && e.code === 'IntlBackslash' && e.shiftKey === true) {
+    this.terminal.onVTKeystroke('˜');
+    return;
+  }
+  if (e.key === 'Dead' && e.code === 'IntlBackslash' && e.shiftKey === false) {
+    this.terminal.onVTKeystroke('`');
+    return;
+  }
+  if (e.key === 'Dead' && e.code === 'Digit6') {
+    this.terminal.onVTKeystroke('ˆ');
+    return;
+  }
   if (e.metaKey || e.altKey) {
     return;
   }


### PR DESCRIPTION
When using an international keyboard mode, certain keys get sent over as 'Dead' keys, as they're meant to be used as modifiers.

This adds a fix which just takes the code, and triggers an insertion for the correct key. See issue here: https://github.com/zeit/hyperterm/issues/518

Ideally we'd want the full composed character support, but until that's working 100% this will get international users up and running.