### PR TITLE
Revert "Use babel for minification (#471)"

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,8 +8,6 @@ const AutoUpdater = require('./auto-updater');
 const toHex = require('convert-css-color-name-to-hex');
 const notify = require('./notify');
 
-app.commandLine.appendSwitch('js-flags', '--harmony');
-
 // set up config
 const config = require('./config');
 config.init();

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-core": "^6.11.4",
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.4",
+    "babel-preset-es2015-native-modules": "^6.9.2",
     "babel-preset-react": "^6.11.1",
     "copy-webpack-plugin": "^3.0.1",
     "electron-builder": "^5.19.1",
@@ -76,6 +77,7 @@
   },
   "babel": {
     "presets": [
+      "es2015-native-modules",
       "react"
     ]
   },
@@ -100,7 +102,7 @@
     "prepublish": "npm test",
     "prepush": "npm test",
     "postinstall": "install-app-deps",
-    "pack": "npm run build && build --dir && babel --no-comments --compact --minified --out-file app/dist/bundle.js app/dist/bundle.js",
+    "pack": "npm run build && build --dir",
     "dist": "npm run build && build",
     "release": "npm run build && build --publish=onTagOrDraft"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,9 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
-        loader: 'babel'
+        loaders: [
+          'babel-loader'
+        ]
       },
       {
         test: /\.json/,
@@ -26,6 +28,23 @@ module.exports = {
     ]
   },
   plugins: [
+    new webpack.ExternalsPlugin('commonjs', ['electron']),
+    new webpack.optimize.UglifyJsPlugin({
+      mangle: {
+        keep_fnames: true
+      },
+      compress: {
+        warnings: false
+      },
+      output: {
+        comments: false
+      },
+      sourceMap: false
+    }),
+    new webpack.LoaderOptionsPlugin({
+      minimize: true,
+      debug: false
+    }),
     new webpack.DefinePlugin({
       'process.env': {
         'NODE_ENV': JSON.stringify(nodeEnv)
@@ -37,6 +56,5 @@ module.exports = {
         to: './assets'
       }
     ])
-  ],
-  target: 'electron'
+  ]
 };


### PR DESCRIPTION
Unfortunately on my Macbook 12 the difference between parsing a 1.5mb JS bundle and a 400kb one is very significant (in the order of 60-100ms consistently added to bootup time).

While I think less transpilation is always good, this is an example of when it's not. Since Uglify doesn't work with modern ES6 features, giving it up is very costly in parsing and interpretation time.