### PR TITLE
Fix build -- Don't force install of next version of electron builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
 
 install:
 - nvm install 6
-- npm install electron-builder@next # force install next version to test electron-builder
 - npm install
 - npm prune
 


### PR DESCRIPTION
We'll just use the version specified in packages.json