### PR TITLE
Add support for environment variables in config

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -54,7 +54,10 @@ module.exports = {
 
     // the shell to run when spawning a new session (i.e. /usr/local/bin/fish)
     // if left empty, your system's login shell will be used by default
-    shell: ''
+    shell: '',
+
+    // for environment variables
+    env: {}
 
     // for advanced config flags please refer to https://hyperterm.org/#cfg
   },

--- a/app/session.js
+++ b/app/session.js
@@ -4,6 +4,7 @@ const { exec } = require('child_process');
 const defaultShell = require('default-shell');
 const { getDecoratedEnv } = require('./plugins');
 const { productName, version } = require('./package');
+const config = require('./config');
 
 let spawn;
 try {
@@ -19,6 +20,8 @@ try {
 
 const TITLE_POLL_INTERVAL = 500;
 
+const envFromConfig = config.getConfig().env || {};
+
 module.exports = class Session extends EventEmitter {
 
   constructor ({ rows, cols: columns, cwd, shell }) {
@@ -28,7 +31,7 @@ module.exports = class Session extends EventEmitter {
       TERM: 'xterm-256color',
       TERM_PROGRAM: productName,
       TERM_PROGRAM_VERSION: version
-    });
+    }, envFromConfig);
 
     this.pty = spawn(shell || defaultShell, ['--login'], {
       columns,


### PR DESCRIPTION
#424 Allows users to specify environment variables in their `.hyperterm.js` under a field named `env`.