### PR TITLE
[WIP] Add proper window support

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -97,7 +97,6 @@ app.on('ready', () => {
     const browserOptions = plugins.getDecoratedBrowserOptions(browserDefaults);
 
     const win = new BrowserWindow(browserOptions);
-
     windowSet.add(win);
 
     win.loadURL(url);
@@ -159,6 +158,7 @@ app.on('ready', () => {
         });
 
         session.on('title', (title) => {
+          win.setTitle(title);
           rpc.emit('session title', { uid, title });
         });
 
@@ -174,14 +174,15 @@ app.on('ready', () => {
     // on Session and focus/blur to subscribe
     rpc.on('focus', ({ uid }) => {
       const session = sessions.get(uid);
-
+      if (typeof session !== 'undefined' && typeof session.lastTitle !== 'undefined') {
+        win.setTitle(session.lastTitle);
+      }
       if (session) {
         session.focus();
       } else {
         console.log('session not found by', uid);
       }
     });
-
     rpc.on('blur', ({ uid }) => {
       const session = sessions.get(uid);
 

--- a/app/index.js
+++ b/app/index.js
@@ -312,8 +312,7 @@ app.on('ready', () => {
 
     // If we're on Mac make a Dock Menu
     if (process.platform === 'darwin') {
-      const {app, Menu} = require('electron');
-
+      const { app, Menu } = require('electron');
       const dockMenu = Menu.buildFromTemplate([
         {label: 'New Window', click () { createWindow(); }}
       ]);

--- a/app/index.js
+++ b/app/index.js
@@ -310,6 +310,16 @@ app.on('ready', () => {
       }
     }));
 
+    // If we're on Mac make a Dock Menu
+    if (process.platform === 'darwin') {
+      const {app, Menu} = require('electron');
+
+      const dockMenu = Menu.buildFromTemplate([
+        {label: 'New Window', click () { createWindow(); }}
+      ]);
+      app.dock.setMenu(dockMenu);
+    }
+
     Menu.setApplicationMenu(Menu.buildFromTemplate(tpl));
   };
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -7,7 +7,6 @@ const appName = app.getName();
 // https://github.com/sindresorhus/anatine/blob/master/menu.js
 
 module.exports = function createMenu ({ createWindow, updatePlugins }) {
-
   const {app, Menu} = require('electron');
 
   const dockMenu = Menu.buildFromTemplate([

--- a/app/menu.js
+++ b/app/menu.js
@@ -208,7 +208,6 @@ module.exports = function createMenu ({ createWindow, updatePlugins }) {
       ]
     },
     {
-      label: 'Window',
       role: 'window',
       submenu: [
         {

--- a/app/menu.js
+++ b/app/menu.js
@@ -7,6 +7,14 @@ const appName = app.getName();
 // https://github.com/sindresorhus/anatine/blob/master/menu.js
 
 module.exports = function createMenu ({ createWindow, updatePlugins }) {
+
+  const {app, Menu} = require('electron');
+
+  const dockMenu = Menu.buildFromTemplate([
+    {label: 'New Window', click () { createWindow(); }}
+  ]);
+  app.dock.setMenu(dockMenu);
+
   return [
     {
       label: 'Application',
@@ -209,6 +217,7 @@ module.exports = function createMenu ({ createWindow, updatePlugins }) {
     },
     {
       label: 'Window',
+      role: 'window',
       submenu: [
         {
           role: 'minimize'

--- a/app/menu.js
+++ b/app/menu.js
@@ -7,13 +7,6 @@ const appName = app.getName();
 // https://github.com/sindresorhus/anatine/blob/master/menu.js
 
 module.exports = function createMenu ({ createWindow, updatePlugins }) {
-  const {app, Menu} = require('electron');
-
-  const dockMenu = Menu.buildFromTemplate([
-    {label: 'New Window', click () { createWindow(); }}
-  ]);
-  app.dock.setMenu(dockMenu);
-
   return [
     {
       label: 'Application',


### PR DESCRIPTION
Adds window switching and title support to the main menu, and the dock menu.

![zukzs1tpoc](https://cloud.githubusercontent.com/assets/47539/17314461/7757882a-585c-11e6-8f09-64ccbf0cf049.gif)

<img width="969" alt="screen shot 2016-08-02 at 02 51 56" src="https://cloud.githubusercontent.com/assets/47539/17314463/7f32287a-585c-11e6-90e3-c8176eb819b1.png">

Adds:
* Switching the window title when the tabs focus changes
* Add the window titles to the Window menu
* Add the titles to the dock menu
* Allow making a new window from the dock