### PR TITLE
File dropped into terminal window adds path to command line

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -3,6 +3,8 @@ const createRPC = require('./rpc');
 const createMenu = require('./menu');
 const uuid = require('uuid');
 const { resolve } = require('path');
+const { parse: parseUrl } = require('url');
+const fileUriToPath = require('file-uri-to-path');
 const isDev = require('electron-is-dev');
 const AutoUpdater = require('./auto-updater');
 const toHex = require('convert-css-color-name-to-hex');
@@ -243,6 +245,17 @@ app.on('ready', () => {
     win.webContents.on('did-navigate', () => {
       if (i++) {
         deleteSessions();
+      }
+    });
+
+    // If file is dropped onto the terminal window, navigate event is prevented
+    // and his path is added to active session.
+    win.webContents.on('will-navigate', (event, url) => {
+      var protocol = typeof url === 'string' && parseUrl(url).protocol;
+      if (protocol === 'file:') {
+        event.preventDefault();
+        let path = fileUriToPath(url).replace(/ /g, '\\ ');
+        rpc.emit('session data send', { data: path });
       }
     });
 

--- a/lib/actions/sessions.js
+++ b/lib/actions/sessions.js
@@ -172,12 +172,16 @@ export function resizeSession (uid, cols, rows) {
 }
 
 export function sendSessionData (uid, data) {
-  return {
-    type: SESSION_USER_DATA,
-    data,
-    effect () {
-      rpc.emit('data', { uid, data });
-    }
+  return function (dispatch, getState) {
+    dispatch({
+      type: SESSION_USER_DATA,
+      data,
+      effect () {
+        // If no uid is passed, data is sended to the active session.
+        const targetUid = uid || getState().sessions.activeUid;
+        rpc.emit('data', { uid: targetUid, data });
+      }
+    });
   };
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,10 @@ rpc.on('session data', ({ uid, data }) => {
   store_.dispatch(sessionActions.addSessionData(uid, data));
 });
 
+rpc.on('session data send', ({ uid, data }) => {
+  store_.dispatch(sessionActions.sendSessionData(uid, data));
+});
+
 rpc.on('session title', ({ uid, title }) => {
   store_.dispatch(sessionActions.setSessionProcessTitle(uid, title));
 });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "aphrodite-simple": "0.4.1",
     "color": "0.11.3",
     "electron-mocha": "^3.0.0",
+    "file-uri-to-path": "0.0.2",
     "hterm-umdjs": "1.1.3",
     "json-loader": "0.5.4",
     "mocha": "^3.0.0",


### PR DESCRIPTION
Since #171 seems to be abandoned, I reimplement his idea, but changing how data is added to session (using actions instead writing directly to term component).

Changes I made:
- 177265f: Added `file-uri-to-path` depencency
- 060ffc2: added rpc event `session data send`, bound to `sendSessionData()` action. `session data` is not suitable to send data in this case 'cause it doesn't add data to session, but only to state.
- e2f13af: if `sendSessionData()` is called without uid (which means that `rpc.emit('session data send')` is emitted without uid), the activeUid is used instead: data will be sent to the active session.
- c212ef2: webContents `will-navigate` event is prevented if a file is dropped onto the terminal window, and his path is sent to the active session (emitting `session data send` rpc event like described in the commit 060ffc2)

Let me know what do you think about these changes, thanks :)
