### PR TITLE
Fix mapXDispatch && allow plugin to access onWheel

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -59,7 +59,10 @@ export default class Term extends Component {
     iframeWindow.addEventListener('wheel', this.onWheel);
   }
 
-  onWheel () {
+  onWheel (e) {
+    if (this.props.onWheel) {
+      this.props.onWheel(e);
+    }
     this.term.prefs_.set('scrollbar-visible', true);
     clearTimeout(this.scrollbarsHideTimer);
     if (!this.scrollMouseEnter) {

--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -266,7 +266,28 @@ export function connect (stateFn, dispatchFn, c, d = {}) {
         });
         return ret;
       },
-      dispatchFn,
+      function (dispatch) {
+        let ret = dispatchFn(dispatch);
+        connectors[name].dispatch.forEach((fn) => {
+          let ret_;
+
+          try {
+            ret_ = fn(dispatch, ret);
+          } catch (err) {
+            console.error(err.stack);
+            notify('Plugin error', `${fn._pluginName}: Error occurred in \`map${name}Dispatch\`. Check Developer Tools for details.`);
+            return;
+          }
+
+          if (!ret_ || 'object' !== typeof ret_) {
+            notify('Plugin error', `${fn._pluginName}: Invalid return value of \`map${name}Dispatch\` (object expected).`);
+            return;
+          }
+
+          ret = ret_;
+        });
+        return ret;
+      },
       c,
       d
     )(decorate(Class, name));


### PR DESCRIPTION
I am building a plugin to support #216. 
But I noticed that `mapXDispatch` functions in plugin are not called at all.
I also need the ability to tap in the `onWheel` function on the `Term`.

This simple PR fix these two issues.