### PR TITLE
Moved "file-uri-to-path" dep to app package.json (fix #566)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "default-shell": "1.0.1",
     "electron-config": "0.2.1",
     "electron-is-dev": "0.1.1",
+    "file-uri-to-path": "0.0.2",
     "gaze": "1.1.0",
     "mkdirp": "0.5.1",
     "ms": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "aphrodite-simple": "0.4.1",
     "color": "0.11.3",
     "electron-mocha": "^3.0.0",
-    "file-uri-to-path": "0.0.2",
     "hterm-umdjs": "1.1.3",
     "json-loader": "0.5.4",
     "mocha": "^3.0.0",


### PR DESCRIPTION
Moved "file-uri-to-path" dependency from root package.json to app/package.json, otherwise an error is thrown by the packaged application. This fix issue #566.
