### PR TITLE
Added shellArgs to the config.

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -56,6 +56,10 @@ module.exports = {
     // if left empty, your system's login shell will be used by default
     shell: '',
 
+    // for setting shell arguments (i.e. for using interactive shellArgs: ['-i'])
+    // by default ['--login'] will be used
+    shellArgs: ['--login'],
+
     // for environment variables
     env: {},
 

--- a/app/index.js
+++ b/app/index.js
@@ -112,7 +112,7 @@ app.on('ready', () => {
 
       win.webContents.send('config change');
 
-      if (cfg_.shell !== cfg.shell) {
+      if (cfg_.shell !== cfg.shell || cfg_.shellArgs !== cfg.shellArgs) {
         notify(
           'Shell configuration changed!',
           'Open a new tab or window to start using the new shell'
@@ -146,8 +146,9 @@ app.on('ready', () => {
 
     rpc.on('new', ({ rows = 40, cols = 100, cwd = process.env.HOME }) => {
       const shell = cfg.shell;
+      const shellArgs = cfg.shellArgs;
 
-      initSession({ rows, cols, cwd, shell }, (uid, session) => {
+      initSession({ rows, cols, cwd, shell, shellArgs }, (uid, session) => {
         sessions.set(uid, session);
         rpc.emit('session add', {
           uid,

--- a/app/session.js
+++ b/app/session.js
@@ -24,7 +24,7 @@ const envFromConfig = config.getConfig().env || {};
 
 module.exports = class Session extends EventEmitter {
 
-  constructor ({ rows, cols: columns, cwd, shell }) {
+  constructor ({ rows, cols: columns, cwd, shell, shellArgs }) {
     super();
     const baseEnv = Object.assign({}, process.env, {
       LANG: app.getLocale().replace('-', '_') + '.UTF-8',
@@ -33,7 +33,9 @@ module.exports = class Session extends EventEmitter {
       TERM_PROGRAM_VERSION: version
     }, envFromConfig);
 
-    this.pty = spawn(shell || defaultShell, ['--login'], {
+    const defaultShellArgs = ['--login'];
+
+    this.pty = spawn(shell || defaultShell, shellArgs || defaultShellArgs, {
       columns,
       rows,
       cwd,


### PR DESCRIPTION
In case someone wants to use non-login shells there is a field added to
the configuration file.
If shellArgs not set default shell will be used as before.

i.e. for using interactive shell (and use .bashrc instead of
.bash_profile on linux) use shellArgs: ['-i'] and shell: '/bin/bash'
this is useful especially if you are on Linux.