### PR TITLE
Use single quotes for better compatibility

### DIFF
--- a/lib/actions/ui.js
+++ b/lib/actions/ui.js
@@ -157,7 +157,7 @@ export function showPreferences () {
               // Leading space prevents command to be store in shell history
               [' echo Attempting to open ~/.hyperterm.js with your \$EDITOR', // eslint-disable-line no-useless-escape
                ' echo If it fails, open it manually with your favorite editor!',
-               ' bash -c "exec env ${EDITOR:=' + editorFallback + '} ~/.hyperterm.js"',
+               ' bash -c \'exec env ${EDITOR:=' + editorFallback + '} ~/.hyperterm.js\'',
                ''
               ].join('\n')
             ));


### PR DESCRIPTION
When attempting to open preferences using `⌘+,` when using fish, i get the following error

```
❯  bash -c "exec env ${EDITOR:=nano} ~/.hyperterm.js"
${ is not a valid variable in fish.
fish:  bash -c "exec env ${EDITOR:=nano} ~/.hyperterm.js"
```

That's because how fish handles single vs double quotes

This PR makes opening preferences work as expected with `fish`, without changing the behaviour when using `bash`, i haven't tested it using `zsh`