### PR TITLE
Open new window offset from last focused window (#573)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -60,9 +60,9 @@ app.on('ready', () => {
     // Open the new window roughly the height of the header away from the
     // previous window. This also ensures in multi monitor setups that the
     // new terminal is on the correct screen.
-    if (BrowserWindow.getFocusedWindow() !== null) {
-      const currentWindow = BrowserWindow.getFocusedWindow();
-      const points = currentWindow.getPosition();
+    const focusedWindow = BrowserWindow.getFocusedWindow() || app.getLastFocusedWindow();
+    if (focusedWindow) {
+      const points = focusedWindow.getPosition();
       const currentScreen = screen.getDisplayNearestPoint({ x: points[0], y: points[1] });
 
       const biggestX = ((points[0] + 100 + width) - currentScreen.bounds.x);


### PR DESCRIPTION
When clicking "new window" in the dock, no window is focused, thus opening it at the same position as the old window.

This PR will make it use our awesome `getLastFocusedWindow` so that it will work as expected even if no window is focused.

Fixes #573 