### PR TITLE
provide backgroundImage option

### DIFF
--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -31,7 +31,7 @@ export default class Term extends Component {
     this.term.prefs_.set('cursor-color', Color(props.cursorColor).rgbString());
     this.term.prefs_.set('enable-clipboard-notice', false);
     this.term.prefs_.set('foreground-color', props.foregroundColor);
-    this.term.prefs_.set('background-color', props.backgroundColor);
+    this.term.prefs_.set('background-color', 'transparent');
     this.term.prefs_.set('color-palette-overrides', getColorList(props.colors));
     this.term.prefs_.set('user-css', this.getStylesheet(props.customCSS));
     this.term.prefs_.set('scrollbar-visible', false);
@@ -180,10 +180,6 @@ export default class Term extends Component {
 
     if (this.props.foregroundColor !== nextProps.foregroundColor) {
       this.term.prefs_.set('foreground-color', nextProps.foregroundColor);
-    }
-
-    if (this.props.backgroundColor !== nextProps.backgroundColor) {
-      this.term.prefs_.set('background-color', nextProps.backgroundColor);
     }
 
     if (this.props.fontFamily !== nextProps.fontFamily) {

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -136,7 +136,6 @@ export default class Terms extends Component {
             fontFamily: this.props.fontFamily,
             fontSmoothing: this.props.fontSmoothing,
             foregroundColor: this.props.foregroundColor,
-            backgroundColor: this.props.backgroundColor,
             colors: this.props.colors,
             url: session.url,
             cleared: session.cleared,


### PR DESCRIPTION
In my current terminal app that I am using I have custom image as background. I'd like to use Hyperterm and I want to have custom background here as well.

After this change, you will be able to add custom background  in configuration: 

```js
module.exports = {
   backgroundImage: 'url(file://path-to-file)',
};
```