### PR TITLE
Add support for Alt modified keys

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -67,10 +67,13 @@ module.exports = {
     bell: 'SOUND',
 
     // if true, selected text will automatically be copied to the clipboard
-    copyOnSelect: false
+    copyOnSelect: false,
 
     // URL to custom bell
     // bellSoundURL: 'http://example.com/bell.mp3',
+
+    // send Alt-x keys to the underlying terminal escaped
+    pass_meta_keys: false
 
     // for advanced config flags please refer to https://hyperterm.org/#cfg
   },

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -102,6 +102,11 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
   }
 
   if (e.metaKey || e.altKey) {
+    if (e.key !== 'Alt' && e.altKey && global.config.getConfig().pass_meta_keys) {
+      // Send this key escaped to the underlying terminal so Emacs will work
+      this.terminal.onVTKeystroke('\x1b' + String.fromCharCode(e.keyCode));
+      e.preventDefault();
+    }
     return;
   } else {
     //  Test for valid keys in order to clear the terminal selection
@@ -109,6 +114,7 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
       selection.clear(this.terminal);
     }
   }
+
   return oldKeyDown.call(this, e);
 };
 


### PR DESCRIPTION
Hi,

  I've been trying to use Emacs under Hyperterm and without meta key support this is very painful. I have made a little patch that allows Emacs to work as expected under Hyperterm. I'm not too happy with the `global` reference, but other than that it seems to work very nicely.

Thanks for making a fun terminal app that is easy to hack on :smile:

Daniel