### PR TITLE
Provide clear selection of text in terminal view

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -64,7 +64,10 @@ module.exports = {
     env: {},
 
     // set to false for no bell
-    bell: 'SOUND'
+    bell: 'SOUND',
+
+    // set to false for no copy-on-select
+    copyOnSelect: false
 
     // URL to custom bell
     // bellSoundURL: 'http://example.com/bell.mp3',

--- a/app/config-default.js
+++ b/app/config-default.js
@@ -66,7 +66,7 @@ module.exports = {
     // set to false for no bell
     bell: 'SOUND',
 
-    // set to false for no copy-on-select
+    // if true, selected text will automatically be copied to the clipboard
     copyOnSelect: false
 
     // URL to custom bell

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -38,12 +38,17 @@ export default class Term extends Component {
     this.term.prefs_.set('receive-encoding', 'raw');
     this.term.prefs_.set('send-encoding', 'raw');
     this.term.prefs_.set('alt-sends-what', 'browser-key');
-    this.term.prefs_.set('copy-on-select', false);
 
     if (props.bell === 'SOUND') {
       this.term.prefs_.set('audible-bell-sound', this.props.bellSoundURL);
     } else {
       this.term.prefs_.set('audible-bell-sound', '');
+    }
+
+    if (props.copyOnSelect) {
+      this.term.prefs_.set('copy-on-select', true);
+    } else {
+      this.term.prefs_.set('copy-on-select', false);
     }
 
     this.term.onTerminalReady = () => {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -221,6 +221,12 @@ export default class Term extends Component {
     } else {
       this.term.prefs_.set('audible-bell-sound', '');
     }
+
+    if (this.props.copyOnSelect) {
+      this.term.prefs_.set('copy-on-select', true);
+    } else {
+      this.term.prefs_.set('copy-on-select', false);
+    }
   }
 
   componentWillUnmount () {

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -38,6 +38,7 @@ export default class Term extends Component {
     this.term.prefs_.set('receive-encoding', 'raw');
     this.term.prefs_.set('send-encoding', 'raw');
     this.term.prefs_.set('alt-sends-what', 'browser-key');
+    this.term.prefs_.set('copy-on-select', false);
 
     if (props.bell === 'SOUND') {
       this.term.prefs_.set('audible-bell-sound', this.props.bellSoundURL);

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -145,7 +145,8 @@ export default class Terms extends Component {
             onData: this.bind(this.props.onData, null, uid),
             onURLAbort: this.bind(this.props.onURLAbort, null, uid),
             bell: this.props.bell,
-            bellSoundURL: this.props.bellSoundURL
+            bellSoundURL: this.props.bellSoundURL,
+            copyOnSelect: this.props.copyOnSelect
           });
           return <div
             key={`d${uid}`}

--- a/lib/containers/terms.js
+++ b/lib/containers/terms.js
@@ -32,7 +32,8 @@ const TermsContainer = connect(
       foregroundColor: state.ui.foregroundColor,
       backgroundColor: state.ui.backgroundColor,
       bell: state.ui.bell,
-      bellSoundURL: state.ui.bellSoundURL
+      bellSoundURL: state.ui.bellSoundURL,
+      copyOnSelect: state.ui.copyOnSelect
     };
   },
   (dispatch) => {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -2,6 +2,12 @@ import { hterm, lib } from 'hterm-umdjs';
 
 hterm.defaultStorage = new lib.Storage.Memory();
 
+//  clear selection range of current selected term view
+//  Fix event when terminal text is selected and keyboard action is invoked
+hterm.Terminal.prototype.clearSelection = function () {
+  this.document_.getSelection().removeAllRanges();
+};
+
 // override double click behavior to copy
 const oldMouse = hterm.Terminal.prototype.onMouse_;
 hterm.Terminal.prototype.onMouse_ = function (e) {
@@ -85,6 +91,11 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
 
   if (e.metaKey || e.altKey) {
     return;
+  } else {
+    //  Test for valid keys in order to clear the terminal selection
+    if ((!e.ctrlKey || e.code !== 'ControlLeft') && !e.shiftKey && e.code !== 'CapsLock') {
+      this.terminal.clearSelection();
+    }
   }
   return oldKeyDown.call(this, e);
 };
@@ -93,6 +104,8 @@ const oldKeyPress = hterm.Keyboard.prototype.onKeyPress_;
 hterm.Keyboard.prototype.onKeyPress_ = function (e) {
   if (e.metaKey) {
     return;
+  } else {
+    this.terminal.clearSelection();
   }
   return oldKeyPress.call(this, e);
 };

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -70,7 +70,8 @@ const initial = Immutable({
   updateVersion: null,
   updateNotes: null,
   bell: 'SOUND',
-  bellSoundURL: 'lib-resource:hterm/audio/bell'
+  bellSoundURL: 'lib-resource:hterm/audio/bell',
+  copyOnSelect: false
 });
 
 const reducer = (state = initial, action) => {
@@ -136,6 +137,10 @@ const reducer = (state = initial, action) => {
 
           if (null !== config.bellSoundURL) {
             ret.bellSoundURL = config.bellSoundURL || initial.bellSoundURL;
+          }
+
+          if (null !== config.copyOnSelect) {
+            ret.copyOnSelect = config.copyOnSelect;
           }
 
           if (null != config.colors) {


### PR DESCRIPTION
- Click on Terminal view now deselect text.
- Valid keyboard event now deselect text.
- Add configuration option for copy-on-select parameter

Fixes #591