### PR TITLE
Add a Dockerfile for easy builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM ubuntu:14.04 
-RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
-RUN apt-get -y install nodejs
+RUN apt-get update
+RUN apt-get install -y curl software-properties-common build-essential git
+RUN sudo add-apt-repository ppa:fkrull/deadsnakes && \
+    sudo apt-get update && \
+    sudo apt-get install -y python2.7 && \
+    ln -s /usr/bin/python2.7 /usr/bin/python
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
+    apt-get -y install nodejs
 ADD . /hyperterm
 VOLUME /hyperterm/dist
 WORKDIR /hyperterm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:14.04 
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN apt-get -y install nodejs
+ADD . /hyperterm
+VOLUME /hyperterm/dist
+WORKDIR /hyperterm
+RUN npm install
+ENTRYPOINT npm run pack

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ If you want to build the binaries for all specified platforms, run the command:
 $ npm run pack
 ```
 
+Or use Docker if your system doesn't meet a dependency.
+```bash
+$ git clone https://github.com/zeit/hyperterm.git
+$ cd hyperterm
+$ docker build -t hyperterm .
+$ docker run -v $(pwd)/dist:/hyperterm/dist hyperterm
+```
+
 After that, you'll see the binaries in the `./dist` folder!
 
 ## Related Repositories


### PR DESCRIPTION
My Mac doesn't meet the dependencies for building this. I'm getting some complaint about my version of Python. I don't really want to mod my Mac for every project's own unique needs these days so I use Dockerfiles as build machines so the build can happen in a container. This is is nice for documenting the requirements for building, documenting the the process for building, and lastly for consistency of builds not to mention avoiding the "Oh shit we lost Bob's laptop, now we can't compile, we have to shut the project down" problem. 

Now the only dependency is Docker so we can do a build like...
```
$ git clone https://github.com/zeit/hyperterm.git
$ cd hyperterm
$ docker build -t hyperterm .
$ docker run -v $(pwd)/dist:/hyperterm/dist hyperterm
```

The result is the same. You'll find a `dist` folder in your hyperterm directory on your host machine with the builds that happened inside the container.

... of course, the result of this still complains about missing Python so the build fails. Can someone solve this? I don't know what version of Python this project requires. Bob does.