### PR TITLE
Memorize window position and size

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -9,7 +9,12 @@ const notify = require('./notify');
 const Config = require('electron-config');
 
 // local storage
-const winCfg = new Config();
+const winCfg = new Config({
+  defaults: {
+    position: [50, 50],
+    size: [540, 380]
+  }
+});
 
 const path = resolve(homedir(), '.hyperterm.js');
 const watchers = [];
@@ -101,11 +106,11 @@ exports.window = {
     let position = winCfg.get('windowPosition');
     let size = winCfg.get('windowSize');
     return {
-      position: (position !== undefined) ? position : [50, 50],
-      size: (size !== undefined) ? size : [540, 340]
+      position: (position !== undefined) ? position : winCfg.store.position,
+      size: (size !== undefined) ? size : winCfg.store.size
     };
   },
-  set (position, size) {
+  set (position, size, cwd) {
     this.position = position;
     this.size = size;
   },

--- a/app/config.js
+++ b/app/config.js
@@ -5,8 +5,8 @@ const vm = require('vm');
 
 const {dialog} = require('electron');
 const gaze = require('gaze');
-const notify = require('./notify');
 const Config = require('electron-config');
+const notify = require('./notify');
 
 // local storage
 const winCfg = new Config({
@@ -100,12 +100,12 @@ exports.getPlugins = function () {
 };
 
 exports.window = {
-  get () {
-    let position = winCfg.get('windowPosition');
-    let size = winCfg.get('windowSize');
+  get() {
+    const position = winCfg.get('windowPosition');
+    const size = winCfg.get('windowSize');
     return {position, size};
   },
-  recordState (win) {
+  recordState(win) {
     winCfg.set('windowPosition', win.getPosition());
     winCfg.set('windowSize', win.getSize());
   }

--- a/app/config.js
+++ b/app/config.js
@@ -94,11 +94,27 @@ exports.getPlugins = function () {
   };
 };
 
-exports.recordWindowState = function (position, size) {
-  cache.set('windowPosition', position);
-  cache.set('windowSize', size);
-};
-
-exports.getWindowState = function () {
-  return {'position': cache.get('windowPosition'), 'size': cache.get('windowSize')};
+exports.window = {
+  position: undefined,
+  size: undefined,
+  get: function () {
+    let position = cache.get('windowPosition');
+    let size = cache.get('windowSize');
+    return {
+      'position': (position !== undefined) ? position : [50, 50],
+      'size': (size !== undefined) ? size : [540, 380]
+    };
+  },
+  set: function (position, size) {
+    this.position = position;
+    this.size = size;
+  },
+  revoke: function () {
+    this.position = undefined;
+    this.size = undefined;
+  },
+  recordState: function (win) {
+    cache.set('windowPosition', win.getPosition());
+    cache.set('windowSize', win.getSize());
+  }
 };

--- a/app/config.js
+++ b/app/config.js
@@ -9,7 +9,7 @@ const notify = require('./notify');
 const Config = require('electron-config');
 
 // local storage
-const cache = new Config();
+const winCfg = new Config();
 
 const path = resolve(homedir(), '.hyperterm.js');
 const watchers = [];
@@ -97,24 +97,24 @@ exports.getPlugins = function () {
 exports.window = {
   position: undefined,
   size: undefined,
-  get: function () {
-    let position = cache.get('windowPosition');
-    let size = cache.get('windowSize');
+  get () {
+    let position = winCfg.get('windowPosition');
+    let size = winCfg.get('windowSize');
     return {
-      'position': (position !== undefined) ? position : [50, 50],
-      'size': (size !== undefined) ? size : [540, 380]
+      position: (position !== undefined) ? position : [50, 50],
+      size: (size !== undefined) ? size : [540, 340]
     };
   },
-  set: function (position, size) {
+  set (position, size) {
     this.position = position;
     this.size = size;
   },
-  revoke: function () {
+  revoke () {
     this.position = undefined;
     this.size = undefined;
   },
-  recordState: function (win) {
-    cache.set('windowPosition', win.getPosition());
-    cache.set('windowSize', win.getSize());
+  recordState (win) {
+    winCfg.set('windowPosition', win.getPosition());
+    winCfg.set('windowSize', win.getSize());
   }
 };

--- a/app/config.js
+++ b/app/config.js
@@ -100,8 +100,6 @@ exports.getPlugins = function () {
 };
 
 exports.window = {
-  position: undefined,
-  size: undefined,
   get () {
     let position = winCfg.get('windowPosition');
     let size = winCfg.get('windowSize');
@@ -109,14 +107,6 @@ exports.window = {
       position: (position !== undefined) ? position : winCfg.store.position,
       size: (size !== undefined) ? size : winCfg.store.size
     };
-  },
-  set (position, size, cwd) {
-    this.position = position;
-    this.size = size;
-  },
-  revoke () {
-    this.position = undefined;
-    this.size = undefined;
   },
   recordState (win) {
     winCfg.set('windowPosition', win.getPosition());

--- a/app/config.js
+++ b/app/config.js
@@ -94,10 +94,11 @@ exports.getPlugins = function () {
   };
 };
 
-exports.recordScreenState = function (screenPosition) {
-  cache.set('screenPosition', screenPosition);
+exports.recordWindowState = function (position, size) {
+  cache.set('windowPosition', position);
+  cache.set('windowSize', size);
 };
 
-exports.getScreenState = function () {
-  return cache.get('screenPosition');
+exports.getWindowState = function () {
+  return {'position': cache.get('windowPosition'), 'size': cache.get('windowSize')};
 };

--- a/app/config.js
+++ b/app/config.js
@@ -11,8 +11,8 @@ const Config = require('electron-config');
 // local storage
 const winCfg = new Config({
   defaults: {
-    position: [50, 50],
-    size: [540, 380]
+    windowPosition: [50, 50],
+    windowSize: [540, 380]
   }
 });
 
@@ -103,10 +103,7 @@ exports.window = {
   get () {
     let position = winCfg.get('windowPosition');
     let size = winCfg.get('windowSize');
-    return {
-      position: (position !== undefined) ? position : winCfg.store.position,
-      size: (size !== undefined) ? size : winCfg.store.size
-    };
+    return {position, size};
   },
   recordState (win) {
     winCfg.set('windowPosition', win.getPosition());

--- a/app/config.js
+++ b/app/config.js
@@ -6,6 +6,10 @@ const vm = require('vm');
 const {dialog} = require('electron');
 const gaze = require('gaze');
 const notify = require('./notify');
+const Config = require('electron-config');
+
+// local storage
+const cache = new Config();
 
 const path = resolve(homedir(), '.hyperterm.js');
 const watchers = [];
@@ -88,4 +92,12 @@ exports.getPlugins = function () {
     plugins: cfg.plugins,
     localPlugins: cfg.localPlugins
   };
+};
+
+exports.recordScreenState = function (screenPosition) {
+  cache.set('screenPosition', screenPosition);
+};
+
+exports.getScreenState = function () {
+  return cache.get('screenPosition');
 };

--- a/app/index.js
+++ b/app/index.js
@@ -65,16 +65,16 @@ const url = 'file://' + resolve(
 console.log('electron will open', url);
 
 app.on('ready', () => installDevExtensions(isDev).then(() => {
-  function createWindow (fn, options = {defaults: {position: undefined, size: undefined}}) {
+  function createWindow (fn, options = {}) {
     let cfg = plugins.getDecoratedConfig();
 
     const winSet = app.config.window.get();
     let [startX, startY] = winSet.position;
 
-    const [width, height] = options.defaults.size !== undefined ? options.defaults.size : (cfg.windowSize || winSet.size);
+    const [width, height] = options.size !== undefined ? options.size : (cfg.windowSize || winSet.size);
     const { screen } = require('electron');
 
-    const winPos = options.defaults.position;
+    const winPos = options.position;
 
     // Open the new window roughly the height of the header away from the
     // previous window. This also ensures in multi monitor setups that the

--- a/app/index.js
+++ b/app/index.js
@@ -65,26 +65,24 @@ const url = 'file://' + resolve(
 console.log('electron will open', url);
 
 app.on('ready', () => installDevExtensions(isDev).then(() => {
-  function createWindow(fn) {
+  function createWindow (fn, options = {defaults: {position: undefined, size: undefined}}) {
     let cfg = plugins.getDecoratedConfig();
 
     const winSet = app.config.window.get();
     let [startX, startY] = winSet.position;
 
-    const [width, height] = app.config.window.size !== undefined ? app.config.window.size : (cfg.windowSize || winSet.size);
+    const [width, height] = options.defaults.size !== undefined ? options.defaults.size : (cfg.windowSize || winSet.size);
     const { screen } = require('electron');
 
-    const winPos = app.config.window.position;
+    const winPos = options.defaults.position;
 
     // Open the new window roughly the height of the header away from the
     // previous window. This also ensures in multi monitor setups that the
     // new terminal is on the correct screen.
     const focusedWindow = BrowserWindow.getFocusedWindow() || app.getLastFocusedWindow();
-    // In case of strictly set position and size, we should ignore the focusedWindow.
+    // In case of options defaults position and size, we should ignore the focusedWindow.
     if (winPos !== undefined) {
       [startX, startY] = winPos;
-      // Revoke config to prevent undesired behavior
-      app.config.window.revoke();
     } else if (focusedWindow) {
       const points = focusedWindow.getPosition();
       const currentScreen = screen.getDisplayNearestPoint({x: points[0], y: points[1]});

--- a/app/index.js
+++ b/app/index.js
@@ -71,10 +71,15 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
     const [width, height] = cfg.windowSize || [540, 380];
     const {screen} = require('electron');
 
-    const start = app.config.getScreenState();
+    const recordedWindow = app.config.getWindowState();
 
-    let startX = (start !== undefined) ? start[0] : 50;
-    let startY = (start !== undefined) ? start[1] : 50;
+    if (recordedWindow !== undefined) {
+      startX = recordedWindow.position[0];
+      startY = recordedWindow.position[1];
+    }
+
+    const [width, height] = cfg.windowSize || ((recordedWindow !== undefined) ? recordedWindow.size : [540, 380]);
+    const { screen } = require('electron');
 
     // Open the new window roughly the height of the header away from the
     // previous window. This also ensures in multi monitor setups that the
@@ -318,7 +323,7 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
 
     // the window can be closed by the browser process itself
     win.on('close', () => {
-      app.config.recordScreenState(win.getPosition());
+      app.config.recordWindowState(win.getPosition(), win.getSize());
       windowSet.delete(win);
       rpc.destroy();
       deleteSessions();

--- a/app/index.js
+++ b/app/index.js
@@ -70,8 +70,7 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
 
     const winSet = app.config.window.get();
 
-    let startX = winSet.position[0];
-    let startY = winSet.position[1];
+    let [startX, startY] = winSet.position;
 
     const [width, height] = app.config.window.size !== undefined ? app.config.window.size : (cfg.windowSize || winSet.size);
     const { screen } = require('electron');
@@ -80,12 +79,9 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
     // previous window. This also ensures in multi monitor setups that the
     // new terminal is on the correct screen.
     const focusedWindow = BrowserWindow.getFocusedWindow() || app.getLastFocusedWindow();
-    // Ignore focusedWindow if createWindow started from ascript or a plugins
-    // setting the position and the size.
-    // Only walid when size and position are strictly set.
+    // In case of strictly set position and size, we should ignore the focusedWindow.
     if (app.config.window.position !== undefined) {
-      startX = app.config.window.position[0];
-      startY = app.config.window.position[1];
+      [startX, startY] = app.config.window.position;
       // Revoke config to prevent undesired behavior
       app.config.window.revoke();
     } else if (focusedWindow) {

--- a/app/index.js
+++ b/app/index.js
@@ -71,8 +71,10 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
     const [width, height] = cfg.windowSize || [540, 380];
     const {screen} = require('electron');
 
-    let startX = 50;
-    let startY = 50;
+    const start = app.config.getScreenState();
+
+    let startX = (start !== undefined) ? start[0] : 50;
+    let startY = (start !== undefined) ? start[1] : 50;
 
     // Open the new window roughly the height of the header away from the
     // previous window. This also ensures in multi monitor setups that the
@@ -222,7 +224,6 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
 
     rpc.on('exit', ({uid}) => {
       const session = sessions.get(uid);
-
       if (session) {
         session.exit();
       } else {
@@ -317,6 +318,7 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
 
     // the window can be closed by the browser process itself
     win.on('close', () => {
+      app.config.recordScreenState(win.getPosition());
       windowSet.delete(win);
       rpc.destroy();
       deleteSessions();

--- a/app/index.js
+++ b/app/index.js
@@ -69,19 +69,20 @@ app.on('ready', () => installDevExtensions(isDev).then(() => {
     let cfg = plugins.getDecoratedConfig();
 
     const winSet = app.config.window.get();
-
     let [startX, startY] = winSet.position;
 
     const [width, height] = app.config.window.size !== undefined ? app.config.window.size : (cfg.windowSize || winSet.size);
     const { screen } = require('electron');
+
+    const winPos = app.config.window.position;
 
     // Open the new window roughly the height of the header away from the
     // previous window. This also ensures in multi monitor setups that the
     // new terminal is on the correct screen.
     const focusedWindow = BrowserWindow.getFocusedWindow() || app.getLastFocusedWindow();
     // In case of strictly set position and size, we should ignore the focusedWindow.
-    if (app.config.window.position !== undefined) {
-      [startX, startY] = app.config.window.position;
+    if (winPos !== undefined) {
+      [startX, startY] = winPos;
       // Revoke config to prevent undesired behavior
       app.config.window.revoke();
     } else if (focusedWindow) {

--- a/app/index.js
+++ b/app/index.js
@@ -65,14 +65,14 @@ const url = 'file://' + resolve(
 console.log('electron will open', url);
 
 app.on('ready', () => installDevExtensions(isDev).then(() => {
-  function createWindow (fn, options = {}) {
+  function createWindow(fn, options = {}) {
     let cfg = plugins.getDecoratedConfig();
 
     const winSet = app.config.window.get();
     let [startX, startY] = winSet.position;
 
-    const [width, height] = options.size !== undefined ? options.size : (cfg.windowSize || winSet.size);
-    const { screen } = require('electron');
+    const [width, height] = options.size ? options.size : (cfg.windowSize || winSet.size);
+    const {screen} = require('electron');
 
     const winPos = options.position;
 


### PR DESCRIPTION
Since Terminal.app dosen't remember window size and only window position, this provide memorizing of the window position on close. On restart, it will use the last saved windows position.

- Use `electron-config` to record window X,Y position
- Use `electron-config` to record window size

Position interpretation order:
- If an `options.position` is set, the parameter is first used
- If the last window position is cached, it will be used 
- then if none of the above, the default `[50, 50]` is used

Size interpretation order:
- if `options.size` is set, the parameter is first used
- if  `windowSize` is set in `hyperterm.js`, the parameter is used as default size
- If the last window size is cached, it will then be used as default
- then if none of the above, the default `[540, 380]` is used

--

Here is a plugin code as en example and the result
```
'use strict';
const { globalShortcut } = require('electron');
exports.onApp = (app) => {
      app.createWindow(undefined,{
            position: [50,50], 
            size: [540,200]
      });
      app.createWindow(undefined, {
          position: [600,50], 
          size: [540,200]
      });
      app.createWindow(undefined, {
          position: [50,260], 
          size: [540,200]
      });
      app.createWindow(undefined, {
          position: [600,260], 
          size: [540,500]
      });
    });
};
```
This result in this:
<img width="1130" alt="screen shot 2016-08-16 at 9 00 27 pm" src="https://cloud.githubusercontent.com/assets/5577409/17720995/8699130a-63f4-11e6-8085-deb4e48b1218.png">

Fix #27
Provide information for windows group layout #311