### PR TITLE
allow plugins to require('react')

### DIFF
--- a/lib/utils/plugins.js
+++ b/lib/utils/plugins.js
@@ -6,6 +6,15 @@ import React from 'react';
 import Notification from '../components/notification';
 import notify from './notify';
 
+var Module = require('module');
+var originalLoad = Module._load;
+Module._load = function (path) {
+  if (path === 'react') {
+    return React;
+  }
+  return originalLoad.apply(this, arguments);
+};
+
 // remote interface to `../plugins`
 let plugins = remote.require('./plugins');
 


### PR DESCRIPTION
Related to #619, this PR allows plugin authors to `require('react')` in their libraries without having to have react as a dependency, and helps avoid ["multiple copies of react" errors](https://facebook.github.io/react/warnings/refs-must-have-owner.html).

It is a fairly hacky solution to patch the `require` function, I'm curious to hear if others have suggestions for an alternative implementation.