### PR TITLE
Add French keyboard compatibility

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -86,6 +86,15 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
       e.preventDefault();
       return;
     }
+    // French keyboard layout
+    if (e.code === 'BracketLeft') {
+      this.terminal.onVTKeystroke('^');
+      return;
+    }
+    if (e.code === 'Backslash') {
+      this.terminal.onVTKeystroke('`');
+      return;
+    }
     console.warn('Uncaught dead key on international keyboard', e);
   }
 


### PR DESCRIPTION
Use #584 trick to add `` ^ `` and `` ` `` keys compatibility with French keyboard.
(until #214 lands)