### PR TITLE
Add dblClick Prevent text expend condition 

### DIFF
--- a/lib/utils/selection.js
+++ b/lib/utils/selection.js
@@ -6,7 +6,12 @@ exports.clear = function (terminal) {
 
 // Use selection extend upon dblclick
 exports.extend = function (terminal) {
-  terminal.screen_.expandSelection(terminal.document_.getSelection());
+  let sel = terminal.document_.getSelection();
+
+  // Test if focusNode exist and nodeName is #text
+  if (sel.focusNode && sel.focusNode.nodeName === '#text') {
+    terminal.screen_.expandSelection(sel);
+  }
 };
 
 // Fix a bug in ScrollPort selectAll behavior


### PR DESCRIPTION
- When dblClick focus was on `X-SCREEN` or when focus was on`X-ROW` with no text, the selection was crashing since no element where selected
