### PR TITLE
Fix errors and crashes on Linux because of `shellArgs` being mutated

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -146,7 +146,7 @@ app.on('ready', () => {
 
     rpc.on('new', ({ rows = 40, cols = 100, cwd = process.env.HOME }) => {
       const shell = cfg.shell;
-      const shellArgs = cfg.shellArgs;
+      const shellArgs = Array.from(cfg.shellArgs);
 
       initSession({ rows, cols, cwd, shell, shellArgs }, (uid, session) => {
         sessions.set(uid, session);


### PR DESCRIPTION
Fixes #661 

The problem was happening when this line executed:
https://github.com/zeit/hyperterm/blob/master/app/session.js#L38
```js
//console.log(shellArgs);
this.pty = spawn(shell || defaultShell, shellArgs || defaultShellArgs, {
      columns,
      rows,
      cwd,
      env: getDecoratedEnv(baseEnv)
});
```

The `console.log(shellArgs)` as in the comment prints the following:

On initial app launch:
```
[ '--login' ]
```

When I try to open a tab:
```
[ 3, '/usr/bin/zsh', '--login' ]
```

Somewhere `shellArgs` is being mutated, so to fix this bug, we're now passing a copy of `shellArgs` into `Session()`