### PR TITLE
issue-656/config-values-arent-scoped

### DIFF
--- a/app/plugins.js
+++ b/app/plugins.js
@@ -93,8 +93,8 @@ function updatePlugins ({ force = false } = {}) {
       const loaded = modules.length;
       const total = paths.plugins.length + paths.localPlugins.length;
       const pluginVersions = JSON.stringify(getPluginVersions());
-      const changed = cache.get('plugin-versions') !== pluginVersions && loaded === total;
-      cache.set('plugin-versions', pluginVersions);
+      const changed = cache.get('hyperterm.plugin-versions') !== pluginVersions && loaded === total;
+      cache.set('hyperterm.plugin-versions', pluginVersions);
 
       // notify watchers
       if (force || changed) {

--- a/app/plugins.js
+++ b/app/plugins.js
@@ -79,7 +79,7 @@ function updatePlugins ({ force = false } = {}) {
       }
     } else {
       // flag successful plugin update
-      cache.set('plugins', id_);
+      cache.set('hyperterm.plugins', id_);
 
       // cache paths
       paths = getPaths(plugins);
@@ -148,7 +148,7 @@ exports.updatePlugins = updatePlugins;
 // we schedule the initial plugins update
 // a bit after the user launches the terminal
 // to prevent slowness
-if (cache.get('plugins') !== id || process.env.HYPERTERM_FORCE_UPDATE) {
+if (cache.get('hyperterm.plugins') !== id || process.env.HYPERTERM_FORCE_UPDATE) {
   // install immediately if the user changed plugins
   console.log('plugins have changed / not init, scheduling plugins installation');
   setTimeout(() => {


### PR DESCRIPTION
Pull request for [#656](https://github.com/zeit/hyperterm/issues/656)

## Changes

- `plugin.js` changed `cache.set('plugins', ...)` to `cache.set('hyperterm.plugins, ...)'`