### PR TITLE
[FIX] return a Redux thunk for the INIT action

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -1,9 +1,13 @@
-import {INIT} from '../constants';
 import rpc from '../rpc';
+import { INIT } from '../constants';
 
-export function init() {
-  rpc.emit('init');
-  return {
-    type: INIT
+export function init () {
+  return (dispatch) => {
+    dispatch({
+      type: INIT,
+      effect: () => {
+        rpc.emit('init');
+      }
+    });
   };
 }


### PR DESCRIPTION
Before, Redux was throwing an error saying that a plain object was not being returned from the `init()` function which was breaking hyperterm.