### PR TITLE
Fix: do not throw when `shellArgs` is not present in `.hyperterm.js`

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -146,7 +146,7 @@ app.on('ready', () => {
 
     rpc.on('new', ({ rows = 40, cols = 100, cwd = process.env.HOME }) => {
       const shell = cfg.shell;
-      const shellArgs = Array.from(cfg.shellArgs);
+      const shellArgs = cfg.shellArgs && Array.from(cfg.shellArgs);
 
       initSession({ rows, cols, cwd, shell, shellArgs }, (uid, session) => {
         sessions.set(uid, session);


### PR DESCRIPTION
See https://github.com/zeit/hyperterm/commit/dfcb0a9629c5624847d7f852188254b322e7de82#commitcomment-18834267 for the discussion. 

Related: dfcb0a9629c5624847d7f852188254b322e7de82, #661, #662