### PR TITLE
Add Setting for modifier Keys cmdIsMeta and altIsMeta

### DIFF
--- a/app/config-default.js
+++ b/app/config-default.js
@@ -67,12 +67,7 @@ module.exports = {
     bell: 'SOUND',
 
     // if true, selected text will automatically be copied to the clipboard
-    copyOnSelect: false,
-
-    modifierKeys: {
-      cmdIsMeta: false,
-      altIsMeta: false
-    }
+    copyOnSelect: false
 
     // URL to custom bell
     // bellSoundURL: 'http://example.com/bell.mp3',

--- a/app/config-default.js
+++ b/app/config-default.js
@@ -67,7 +67,12 @@ module.exports = {
     bell: 'SOUND',
 
     // if true, selected text will automatically be copied to the clipboard
-    copyOnSelect: false
+    copyOnSelect: false,
+
+    modifierKeys: {
+      cmdIsMeta: false,
+      altIsMeta: false
+    }
 
     // URL to custom bell
     // bellSoundURL: 'http://example.com/bell.mp3',

--- a/lib/components/term.js
+++ b/lib/components/term.js
@@ -61,6 +61,7 @@ export default class Term extends Component {
         }
       };
 
+      this.term.modifierKeys = props.modifierKeys;
       // this.term.CursorNode_ is available at this point.
       this.term.setCursorShape(props.cursorShape);
     };

--- a/lib/components/terms.js
+++ b/lib/components/terms.js
@@ -152,7 +152,8 @@ export default class Terms extends Component {
             onURLAbort: this.bind(this.props.onURLAbort, null, uid),
             bell: this.props.bell,
             bellSoundURL: this.props.bellSoundURL,
-            copyOnSelect: this.props.copyOnSelect
+            copyOnSelect: this.props.copyOnSelect,
+            modifierKeys: this.props.modifierKeys
           });
           return (<div
             key={`d${uid}`}

--- a/lib/containers/terms.js
+++ b/lib/containers/terms.js
@@ -33,7 +33,8 @@ const TermsContainer = connect(
       backgroundColor: state.ui.backgroundColor,
       bell: state.ui.bell,
       bellSoundURL: state.ui.bellSoundURL,
-      copyOnSelect: state.ui.copyOnSelect
+      copyOnSelect: state.ui.copyOnSelect,
+      modifierKeys: state.ui.modifierKeys
     };
   },
   dispatch => {

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -102,6 +102,24 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
     console.warn('Uncaught dead key on international keyboard', e);
   }
 
+  const modifierKeysConf = global.config.getConfig().modifierKeys;
+  if (e.altKey &&
+      e.code !== 'alt' &&
+      e.code !== 'altLeft' &&
+      e.code !== 'altRight' &&
+      modifierKeysConf.altIsMeta) {
+    this.terminal.onVTKeystroke('\x1b' + String.fromCharCode(e.keyCode));
+    e.preventDefault();
+  }
+
+  if (e.metaKey &&
+      e.code !== 'MetaLeft' &&
+      e.code !== 'MetaRight' &&
+      modifierKeysConf.cmdIsMeta) {
+    this.terminal.onVTKeystroke('\x1b' + String.fromCharCode(e.keyCode));
+    e.preventDefault();
+  }
+
   if (e.metaKey || e.altKey || (e.ctrlKey && e.code === 'Tab')) {
     return;
   }

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -102,7 +102,7 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
     console.warn('Uncaught dead key on international keyboard', e);
   }
 
-  const modifierKeysConf = global.config.getConfig().modifierKeys;
+  const modifierKeysConf = this.terminal.modifierKeys;
   if (e.altKey &&
       e.code !== 'alt' &&
       e.code !== 'altLeft' &&

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -71,7 +71,11 @@ const initial = Immutable({
   updateNotes: null,
   bell: 'SOUND',
   bellSoundURL: 'lib-resource:hterm/audio/bell',
-  copyOnSelect: false
+  copyOnSelect: false,
+  modifierKeys: {
+    altIsMeta: false,
+    cmdIsMeta: false
+  }
 });
 
 const reducer = (state = initial, action) => {
@@ -155,6 +159,10 @@ const reducer = (state = initial, action) => {
             } else if (JSON.stringify(state.colors) !== JSON.stringify(config.colors)) {
               ret.colors = config.colors;
             }
+          }
+
+          if (null != config.modifierKeys) {
+            ret.modifierKeys = config.modifierKeys;
           }
 
           return ret;

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -161,7 +161,7 @@ const reducer = (state = initial, action) => {
             }
           }
 
-          if (null != config.modifierKeys) {
+          if (config.modifierKeys !== null) {
             ret.modifierKeys = config.modifierKeys;
           }
 


### PR DESCRIPTION
Adds a setting to allow the user to use the Cmd Key (OSX) or alt Key as meta.

Tried to pick sensible setting names for that.

I also tried another solution, using the hterm setting `term_.prefs_.set('alt-is-meta', true)`. But for some reason even when I set up this value to true, it does not work. There is something I am not understanding there.