### PR TITLE
Add missing dependency "color"

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
   "description": "HTML/JS/CSS Terminal",
   "dependencies": {
     "child_pty": "3.0.1",
+    "color": "0.11.3",
     "convert-css-color-name-to-hex": "0.1.1",
     "default-shell": "1.0.1",
     "electron-config": "0.2.1",


### PR DESCRIPTION
The current master is not executable. The `color` dependency is missing, see screenshot:

![screenshot](https://cloud.githubusercontent.com/assets/457834/18678659/05cb7ca2-7f5d-11e6-915e-48f9e54e1252.jpg)
