### PR TITLE
In development, use git-describe for appVersion

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -9,6 +9,7 @@ const isDev = require('electron-is-dev');
 const AutoUpdater = require('./auto-updater');
 const toElectronBackgroundColor = require('./utils/to-electron-background-color');
 const notify = require('./notify');
+const { gitDescribe } = require('git-describe');
 
 app.commandLine.appendSwitch('js-flags', '--harmony');
 
@@ -36,6 +37,11 @@ app.getLastFocusedWindow = () => {
 
 if (isDev) {
   console.log('running in dev mode');
+
+  // Overide default appVersion which is set from package.json
+  gitDescribe({customArguments: ['--tags']}, (error, gitInfo) => {
+    if (!error) app.setVersion(gitInfo.raw);
+  });
 } else {
   console.log('running in prod mode');
 }

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "electron-is-dev": "0.1.1",
     "file-uri-to-path": "0.0.2",
     "gaze": "1.1.0",
+    "git-describe": "3.0.2",
     "mkdirp": "0.5.1",
     "ms": "0.7.1",
     "shell-env": "0.2.0",


### PR DESCRIPTION
## Before:
![image](https://cloud.githubusercontent.com/assets/8813276/18684084/87c933d6-7f38-11e6-8584-1135433f4648.png)

## After:
![image](https://cloud.githubusercontent.com/assets/8813276/18684059/7028febe-7f38-11e6-8f84-f1d249d15aba.png)

Normally `appVersion` is set from `package.json`'s `version` field.

This looks goofy right now since `package.json` is set to `1.0.0` but the `1.0.0` git tag hasn't been created yet.

closes #718