### PR TITLE
Fix ava tests on Linux by setting correct path to the built binary

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -8,8 +8,23 @@ import {Application} from 'spectron';
 let app;
 
 test.before(async () => {
+  let pathToBinary;
+
+  switch (process.platform) {
+    case 'linux':
+      pathToBinary = path.join(__dirname, '../dist/linux-unpacked/HyperTerm');
+      break;
+
+    case 'darwin':
+      pathToBinary = path.join(__dirname, '../dist/mac/HyperTerm.app/Contents/MacOS/HyperTerm');
+      break;
+
+    default:
+      throw new Error('Path to the built binary needs to be defined for this platform in test/index.js');
+  }
+
   app = new Application({
-    path: path.join(__dirname, '../dist/mac/HyperTerm.app/Contents/MacOS/HyperTerm')
+    path: pathToBinary
   });
 
   await app.start();


### PR DESCRIPTION
This adds the path to the Linux binary in `test/index.js`.

I don't know what the path is for windows, so for any platforms where the path isn't defined, it'll throw an error telling you that this path needs defined for your platform.

Closes #750 