### PR TITLE
On Linux/Windows, hide OSX specific menu items and change 'Shell' to 'File'

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -8,260 +8,284 @@ const appName = app.getName();
 // https://github.com/sindresorhus/anatine/blob/master/menu.js
 
 module.exports = function createMenu({createWindow, updatePlugins}) {
-  return [
-    {
-      label: 'Application',
-      submenu: [
-        {
-          role: 'about'
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'Preferences...',
-          accelerator: 'Cmd+,',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('preferences');
-            } else {
-              createWindow(win => win.rpc.emit('preferences'));
-            }
+  const osxApplicationMenu = {
+    // This menu label is overrided by OSX to be the appName
+    // The label is set to appName here so it matches actual behavior
+    label: appName,
+    submenu: [
+      {
+        role: 'about'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Preferences...',
+        accelerator: 'Cmd+,',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('preferences');
+          } else {
+            createWindow(win => win.rpc.emit('preferences'));
           }
-        },
-        {
-          type: 'separator'
-        },
-        {
-          role: 'services',
-          submenu: []
-        },
-        {
-          type: 'separator'
-        },
-        {
-          role: 'hide'
-        },
-        {
-          role: 'hideothers'
-        },
-        {
-          role: 'unhide'
-        },
-        {
-          type: 'separator'
-        },
-        {
-          role: 'quit'
         }
-      ]
-    },
-    {
-      label: 'Shell',
-      submenu: [
-        {
-          label: 'New Window',
-          accelerator: 'CmdOrCtrl+N',
-          click() {
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'services',
+        submenu: []
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'hide'
+      },
+      {
+        role: 'hideothers'
+      },
+      {
+        role: 'unhide'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'quit'
+      }
+    ]
+  };
+
+  const shellOrFileMenu = {
+    label: process.platform === 'darwin' ? 'Shell' : 'File',
+    submenu: [
+      {
+        label: 'New Window',
+        accelerator: 'CmdOrCtrl+N',
+        click() {
+          createWindow();
+        }
+      },
+      {
+        label: 'New Tab',
+        accelerator: 'CmdOrCtrl+T',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('session add req');
+          } else {
             createWindow();
           }
-        },
-        {
-          label: 'New Tab',
-          accelerator: 'CmdOrCtrl+T',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('session add req');
-            } else {
-              createWindow();
-            }
-          }
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'Close',
-          accelerator: 'CmdOrCtrl+W',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('session close req');
-            }
-          }
-        },
-        {
-          label: 'Close Terminal Window',
-          role: 'close',
-          accelerator: 'CmdOrCtrl+Shift+W'
         }
-      ]
-    },
-    {
-      label: 'Edit',
-      submenu: [
-        {
-          role: 'undo'
-        },
-        {
-          role: 'redo'
-        },
-        {
-          type: 'separator'
-        },
-        {
-          role: 'cut'
-        },
-        {
-          role: 'copy'
-        },
-        {
-          role: 'paste'
-        },
-        {
-          role: 'selectall'
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'Clear',
-          accelerator: 'CmdOrCtrl+K',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('session clear req');
-            }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Close',
+        accelerator: 'CmdOrCtrl+W',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('session close req');
           }
         }
-      ]
-    },
-    {
-      label: 'View',
-      submenu: [
-        {
-          label: 'Reload',
-          accelerator: 'CmdOrCtrl+R',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('reload');
-            }
-          }
-        },
-        {
-          label: 'Full Reload',
-          accelerator: 'CmdOrCtrl+Shift+R',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.reload();
-            }
-          }
-        },
-        {
-          label: 'Toggle Developer Tools',
-          accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.webContents.toggleDevTools();
-            }
-          }
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'Reset Zoom Level',
-          accelerator: 'CmdOrCtrl+0',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('reset fontSize req');
-            }
-          }
-        },
-        {
-          label: 'Zoom In',
-          accelerator: 'CmdOrCtrl+plus',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('increase fontSize req');
-            }
-          }
-        },
-        {
-          label: 'Zoom Out',
-          accelerator: 'CmdOrCtrl+-',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('decrease fontSize req');
-            }
+      },
+      {
+        label: process.platform === 'darwin' ? 'Close Terminal Window' : 'Quit',
+        role: 'close',
+        accelerator: 'CmdOrCtrl+Shift+W'
+      }
+    ]
+  };
+
+  const editMenu = {
+    label: 'Edit',
+    submenu: [
+      {
+        role: 'undo'
+      },
+      {
+        role: 'redo'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'cut'
+      },
+      {
+        role: 'copy'
+      },
+      {
+        role: 'paste'
+      },
+      {
+        role: 'selectall'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Clear',
+        accelerator: 'CmdOrCtrl+K',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('session clear req');
           }
         }
-      ]
-    },
-    {
-      label: 'Plugins',
-      submenu: [
-        {
-          label: 'Update All Now',
-          accelerator: 'CmdOrCtrl+Shift+U',
-          click() {
-            updatePlugins();
+      }
+    ]
+  };
+
+  if (process.platform !== 'darwin') {
+    editMenu.submenu.push(
+      {type: 'separator'},
+      {
+        label: 'Preferences...',
+        accelerator: 'Cmd+,',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('preferences');
+          } else {
+            createWindow(win => win.rpc.emit('preferences'));
           }
         }
-      ]
-    },
-    {
-      role: 'window',
-      submenu: [
-        {
-          role: 'minimize'
-        },
-        {
-          role: 'zoom'
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label: 'Show Previous Tab',
-          accelerator: 'CmdOrCtrl+Option+Left',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('move left req');
-            }
+      }
+    );
+  }
+
+  const viewMenu = {
+    label: 'View',
+    submenu: [
+      {
+        label: 'Reload',
+        accelerator: 'CmdOrCtrl+R',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('reload');
           }
-        },
-        {
-          label: 'Show Next Tab',
-          accelerator: 'CmdOrCtrl+Option+Right',
-          click(item, focusedWindow) {
-            if (focusedWindow) {
-              focusedWindow.rpc.emit('move right req');
-            }
-          }
-        },
-        {
-          type: 'separator'
-        },
-        {
-          role: 'front'
-        },
-        {
-          role: 'togglefullscreen'
         }
-      ]
-    },
-    {
-      role: 'help',
-      submenu: [
-        {
-          label: `${appName} Website`,
-          click() {
-            shell.openExternal('https://hyperterm.now.sh');
+      },
+      {
+        label: 'Full Reload',
+        accelerator: 'CmdOrCtrl+Shift+R',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.reload();
           }
-        },
-        {
-          label: 'Report an Issue...',
-          click() {
-            const body = `
+        }
+      },
+      {
+        label: 'Toggle Developer Tools',
+        accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.webContents.toggleDevTools();
+          }
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Reset Zoom Level',
+        accelerator: 'CmdOrCtrl+0',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('reset fontSize req');
+          }
+        }
+      },
+      {
+        label: 'Zoom In',
+        accelerator: 'CmdOrCtrl+plus',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('increase fontSize req');
+          }
+        }
+      },
+      {
+        label: 'Zoom Out',
+        accelerator: 'CmdOrCtrl+-',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('decrease fontSize req');
+          }
+        }
+      }
+    ]
+  };
+
+  const pluginsMenu = {
+    label: 'Plugins',
+    submenu: [
+      {
+        label: 'Update All Now',
+        accelerator: 'CmdOrCtrl+Shift+U',
+        click() {
+          updatePlugins();
+        }
+      }
+    ]
+  };
+
+  const windowMenu = {
+    role: 'window',
+    submenu: [
+      {
+        role: 'minimize'
+      },
+      {
+        role: 'zoom'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Show Previous Tab',
+        accelerator: 'CmdOrCtrl+Option+Left',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('move left req');
+          }
+        }
+      },
+      {
+        label: 'Show Next Tab',
+        accelerator: 'CmdOrCtrl+Option+Right',
+        click(item, focusedWindow) {
+          if (focusedWindow) {
+            focusedWindow.rpc.emit('move right req');
+          }
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'front'
+      },
+      {
+        role: 'togglefullscreen'
+      }
+    ]
+  };
+
+  const helpMenu = {
+    role: 'help',
+    submenu: [
+      {
+        label: `${appName} Website`,
+        click() {
+          shell.openExternal('https://hyperterm.now.sh');
+        }
+      },
+      {
+        label: 'Report an Issue...',
+        click() {
+          const body = `
 <!-- Please succinctly describe your issue and steps to reproduce it. -->
 
 -
@@ -270,29 +294,39 @@ ${app.getName()} ${app.getVersion()}
 Electron ${process.versions.electron}
 ${process.platform} ${process.arch} ${os.release()}`;
 
-            shell.openExternal(`https://github.com/zeit/hyperterm/issues/new?body=${encodeURIComponent(body)}`);
-          }
-        },
-        ...(
-          process.platform === 'darwin' ?
-            [] :
-            [
-                {type: 'separator'},
-              {
-                role: 'about',
-                click() {
-                  dialog.showMessageBox({
-                    title: `About ${appName}`,
-                    message: `${appName} ${app.getVersion()}`,
-                    detail: 'Created by Guillermo Rauch',
-                    icon: path.join(__dirname, 'static/icon.png'),
-                    buttons: []
-                  });
-                }
-              }
-            ]
-        )
-      ]
-    }
-  ];
+          shell.openExternal(`https://github.com/zeit/hyperterm/issues/new?body=${encodeURIComponent(body)}`);
+        }
+      }
+    ]
+  };
+
+  if (process.platform !== 'darwin') {
+    helpMenu.submenu.push(
+      {type: 'separator'},
+      {
+        role: 'about',
+        click() {
+          dialog.showMessageBox({
+            title: `About ${appName}`,
+            message: `${appName} ${app.getVersion()}`,
+            detail: 'Created by Guillermo Rauch',
+            icon: path.join(__dirname, 'static/icon.png'),
+            buttons: []
+          });
+        }
+      }
+    );
+  }
+
+  const menu = [].concat(
+    process.platform === 'darwin' ? osxApplicationMenu : [],
+    shellOrFileMenu,
+    editMenu,
+    viewMenu,
+    pluginsMenu,
+    windowMenu,
+    helpMenu
+  );
+
+  return menu;
 };


### PR DESCRIPTION
This PR:

1. Refactors `app/menu.js` so each menu is a separate object. 
    - This makes it easier to understand each separate menu and rearrange them if needed.
    - It's also easier to conditionally add entire menus based on platform type
2. Hides all OSX specific items on Linux and Windows. Based on [this Electron document](https://github.com/electron/electron/blob/master/docs/api/menu.md#user-content-notes-on-os-x-application-menu).
    - Mainly, this hides the first 'Application' menu.
3. Renames the `Shell` menu as `File` on Linux and Windows for a more native feel. 
4. Adds the `Preferences` menu item to `Edit` on Linux and Windows for a more native feel and because the original `Application` menu is no longer shown on these platforms.
5. Renames the `Close Terminal Window` menu item to `Quit` on Linux and Windows because that's [the current behavior](https://github.com/zeit/hyperterm/blob/master/app/index.js#L327-L332).

Fixes #122 