### PR TITLE
redux-logger TYPE emitting

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -1,5 +1,16 @@
 import rpc from '../rpc';
 
+import {
+  INIT
+} from '../constants/index';
+
 export function init() {
-  rpc.emit('init');
+  return dispatch => {
+    dispatch({
+      type: INIT,
+      effect() {
+        rpc.emit('init');
+      }
+    });
+  };
 }


### PR DESCRIPTION
- use constant `INIT` in `init()` dispatch function
- error was due to non-dispatching action