### PR TITLE
Fix ^ for the BÉPO keyboard layout

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -99,6 +99,11 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
       this.terminal.onVTKeystroke('`');
       return;
     }
+    // BÉPO keyboard layout
+    if (e.code === 'KeyY') {
+      this.terminal.onVTKeystroke('^');
+      return;
+    }
     console.warn('Uncaught dead key on international keyboard', e);
   }
 


### PR DESCRIPTION
Tons of dead keys are broken when you use BÉPO keyboard layout, but I particularly miss '^' :)