### PR TITLE
Replace explicit null check with isNil

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -31,7 +31,7 @@ hterm.Terminal.prototype.overlaySize = function () {};
 // in an infinite copy loop
 hterm.Terminal.prototype.copySelectionToClipboard = function () {
   const text = this.getSelectionText();
-  if (text !== null && text !== '') {
+  if (text) {
     this.copyStringToClipboard(text);
   }
 };

--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -95,15 +95,15 @@ const reducer = (state = initial, action) => {
             ret.fontSizeOverride = null;
           }
 
-          if (config.fontSize !== null) {
+          if (config.fontSize) {
             ret.fontSize = config.fontSize;
           }
 
-          if (config.fontFamily !== null) {
+          if (config.fontFamily) {
             ret.fontFamily = config.fontFamily;
           }
 
-          if (config.cursorColor !== null) {
+          if (config.cursorColor) {
             ret.cursorColor = config.cursorColor;
           }
 
@@ -111,27 +111,27 @@ const reducer = (state = initial, action) => {
             ret.cursorShape = config.cursorShape;
           }
 
-          if (config.borderColor !== null) {
+          if (config.borderColor) {
             ret.borderColor = config.borderColor;
           }
 
-          if (config.padding !== null) {
+          if (config.padding != null) {
             ret.padding = config.padding;
           }
 
-          if (config.foregroundColor !== null) {
+          if (config.foregroundColor) {
             ret.foregroundColor = config.foregroundColor;
           }
 
-          if (config.backgroundColor !== null) {
+          if (config.backgroundColor) {
             ret.backgroundColor = config.backgroundColor;
           }
 
-          if (config.css !== null) {
+          if (config.css) {
             ret.css = config.css;
           }
 
-          if (config.termCSS !== null) {
+          if (config.termCSS) {
             ret.termCSS = config.termCSS;
           }
 
@@ -139,15 +139,15 @@ const reducer = (state = initial, action) => {
             ret.bell = config.bell;
           }
 
-          if (config.bellSoundURL !== null) {
+          if (config.bellSoundURL) {
             ret.bellSoundURL = config.bellSoundURL || initial.bellSoundURL;
           }
 
-          if (config.copyOnSelect !== null) {
+          if (config.copyOnSelect != null) {
             ret.copyOnSelect = config.copyOnSelect;
           }
 
-          if (config.colors !== null) {
+          if (config.colors) {
             if (Array.isArray(config.colors)) {
               const stateColors = Array.isArray(state.colors) ?
                 state.colors :
@@ -161,7 +161,7 @@ const reducer = (state = initial, action) => {
             }
           }
 
-          if (config.modifierKeys !== null) {
+          if (config.modifierKeys) {
             ret.modifierKeys = config.modifierKeys;
           }
 
@@ -290,7 +290,7 @@ const reducer = (state = initial, action) => {
     }
   }
 
-  if (state.cols !== null && state.rows !== null &&
+  if (state.cols != null && state.rows != null &&
      (state.rows !== state_.rows ||
       state.cols !== state_.cols)) {
     state_ = state_.merge({notifications: {resize: true}}, {deep: true});

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
       "mocha"
     ],
     "rules": {
+      "eqeqeq": ["error", "allow-null"],
+      "no-eq-null": 0,
       "react/prop-types": 0,
       "babel/new-cap": 0,
       "quote-props": 0,


### PR DESCRIPTION
This replaces the explicit `!== null` checks we have in the UI reducer with basically `!== null && !== undefined`. This was breaking the changes introduced in #686, as `modifierKeys` would be overriden by `undefined`. 

Basically this reintroduces the behavior we had pre #723 (with `!= null`).