### PR TITLE
Ensure modifierKeys config is set before reading

### DIFF
--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -107,6 +107,7 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
       e.code !== 'alt' &&
       e.code !== 'altLeft' &&
       e.code !== 'altRight' &&
+      modifierKeysConf &&
       modifierKeysConf.altIsMeta) {
     this.terminal.onVTKeystroke('\x1b' + String.fromCharCode(e.keyCode));
     e.preventDefault();
@@ -115,6 +116,7 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
   if (e.metaKey &&
       e.code !== 'MetaLeft' &&
       e.code !== 'MetaRight' &&
+      modifierKeysConf &&
       modifierKeysConf.cmdIsMeta) {
     this.terminal.onVTKeystroke('\x1b' + String.fromCharCode(e.keyCode));
     e.preventDefault();


### PR DESCRIPTION
This PR ensures the `modifierKeys` config is set before trying to reading the options from it, preventing a TypeError from being thrown.