### PR TITLE
Preserve multi-byte encoded utf-8 characters

### DIFF
--- a/app/session.js
+++ b/app/session.js
@@ -1,5 +1,6 @@
 const {exec} = require('child_process');
 const {EventEmitter} = require('events');
+const {StringDecoder} = require('string_decoder');
 
 const {app} = require('electron');
 const defaultShell = require('default-shell');
@@ -35,6 +36,8 @@ module.exports = class Session extends EventEmitter {
       TERM_PROGRAM_VERSION: version
     }, envFromConfig);
 
+    const decoder = new StringDecoder('utf8');
+
     const defaultShellArgs = ['--login'];
 
     this.pty = spawn(shell || defaultShell, shellArgs || defaultShellArgs, {
@@ -48,7 +51,7 @@ module.exports = class Session extends EventEmitter {
       if (this.ended) {
         return;
       }
-      this.emit('data', data.toString('utf8'));
+      this.emit('data', decoder.write(data));
     });
 
     this.pty.on('exit', () => {


### PR DESCRIPTION
This PR tweaks the session data emitter to properly decode the data buffer using a [`StringDecoder`](https://nodejs.org/api/string_decoder.html).

>The string_decoder module provides an API for decoding Buffer objects into strings in a manner that preserves encoded multi-byte UTF-8 and UTF-16 characters. 

This fixes the issue seen in #701.