### PR TITLE
split panes: set hotkeys based on OS

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -2,6 +2,7 @@ const os = require('os');
 const path = require('path');
 const {app, shell, dialog} = require('electron');
 
+const isMac = process.platform === 'darwin';
 const appName = app.getName();
 
 // based on and inspired by
@@ -59,7 +60,7 @@ module.exports = function createMenu({createWindow, updatePlugins}) {
   };
 
   const shellOrFileMenu = {
-    label: process.platform === 'darwin' ? 'Shell' : 'File',
+    label: isMac ? 'Shell' : 'File',
     submenu: [
       {
         label: 'New Window',
@@ -84,7 +85,7 @@ module.exports = function createMenu({createWindow, updatePlugins}) {
       },
       {
         label: 'Split Vertically',
-        accelerator: 'Ctrl+Shift+E',
+        accelerator: isMac ? 'Cmd+D' : 'Ctrl+Shift+E',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('split request vertical');
@@ -93,7 +94,7 @@ module.exports = function createMenu({createWindow, updatePlugins}) {
       },
       {
         label: 'Split Horizontally',
-        accelerator: 'Ctrl+Shift+O',
+        accelerator: isMac ? 'Cmd+Shift+D' : 'Ctrl+Shift+O',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.rpc.emit('split request horizontal');
@@ -113,7 +114,7 @@ module.exports = function createMenu({createWindow, updatePlugins}) {
         }
       },
       {
-        label: process.platform === 'darwin' ? 'Close Terminal Window' : 'Quit',
+        label: isMac ? 'Close Terminal Window' : 'Quit',
         role: 'close',
         accelerator: 'CmdOrCtrl+Shift+W'
       }
@@ -159,7 +160,7 @@ module.exports = function createMenu({createWindow, updatePlugins}) {
     ]
   };
 
-  if (process.platform !== 'darwin') {
+  if (!isMac) {
     editMenu.submenu.push(
       {type: 'separator'},
       {
@@ -199,7 +200,7 @@ module.exports = function createMenu({createWindow, updatePlugins}) {
       },
       {
         label: 'Toggle Developer Tools',
-        accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+        accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.webContents.toggleDevTools();
@@ -342,7 +343,7 @@ ${process.platform} ${process.arch} ${os.release()}`;
     ]
   };
 
-  if (process.platform !== 'darwin') {
+  if (!isMac) {
     helpMenu.submenu.push(
       {type: 'separator'},
       {
@@ -361,7 +362,7 @@ ${process.platform} ${process.arch} ${os.release()}`;
   }
 
   const menu = [].concat(
-    process.platform === 'darwin' ? osxApplicationMenu : [],
+    isMac ? osxApplicationMenu : [],
     shellOrFileMenu,
     editMenu,
     viewMenu,

--- a/lib/containers/hyperterm.js
+++ b/lib/containers/hyperterm.js
@@ -4,7 +4,6 @@ import React from 'react';
 import Component from '../component';
 import {connect} from '../utils/plugins';
 import * as uiActions from '../actions/ui';
-import * as termGroupActions from '../actions/term-groups';
 
 import HeaderContainer from './header';
 import TermsContainer from './terms';
@@ -35,7 +34,7 @@ class HyperTerm extends Component {
   }
 
   attachKeyListeners() {
-    const {moveTo, moveLeft, moveRight, splitHorizontal, splitVertical} = this.props;
+    const {moveTo, moveLeft, moveRight} = this.props;
     const term = this.terms.getActiveTerm();
     if (!term) {
       return;
@@ -43,11 +42,6 @@ class HyperTerm extends Component {
     const lastIndex = this.terms.getLastTermIndex();
     const document = term.getTermDocument();
     const keys = new Mousetrap(document);
-    if (process.platform === 'darwin') {
-      keys.bind('command+d', splitVertical);
-      keys.bind('command+shift+d', splitHorizontal);
-    }
-
     keys.bind('command+1', moveTo.bind(this, 0));
     keys.bind('command+2', moveTo.bind(this, 1));
     keys.bind('command+3', moveTo.bind(this, 2));
@@ -158,14 +152,6 @@ const HyperTermContainer = connect(
 
       moveRight: () => {
         dispatch(uiActions.moveRight());
-      },
-
-      splitHorizontal: () => {
-        dispatch(termGroupActions.requestHorizontalSplit());
-      },
-
-      splitVertical: () => {
-        dispatch(termGroupActions.requestVerticalSplit());
       }
     };
   },

--- a/lib/hterm.js
+++ b/lib/hterm.js
@@ -3,14 +3,6 @@ import fromCharCode from './utils/key-code';
 
 const selection = require('./utils/selection');
 
-// Keys that are used in combination
-// with ctrl based hotkeys:
-const IGNORED_CTRL_KEYS = [
-  'Tab',
-  'KeyO',
-  'KeyE'
-];
-
 hterm.defaultStorage = new lib.Storage.Memory();
 
 // Provide selectAll to terminal viewport
@@ -137,7 +129,7 @@ hterm.Keyboard.prototype.onKeyDown_ = function (e) {
     e.preventDefault();
   }
 
-  if (e.metaKey || e.altKey || (e.ctrlKey && IGNORED_CTRL_KEYS.includes(e.code))) {
+  if (e.metaKey || e.altKey || (e.ctrlKey && e.code === 'Tab')) {
     return;
   }
   if ((!e.ctrlKey || e.code !== 'ControlLeft') && !e.shiftKey && e.code !== 'CapsLock') {


### PR DESCRIPTION
Forgot to include this in the last PR. This sets the split hotkeys based on what OS you're on, so that the correct hotkeys show in the menu. The hotkeys are still the same:

macOS:
* Vertical split: `Cmd + D`
* Horizontal split: `Cmd + Shift + D`

Other:
* Vertical split: `Ctrl+Shift+E`
* Horizontal split: `Ctrl+Shift+O`