### PR TITLE
Make sure focused tabs don't get activity highlighted

### DIFF
--- a/lib/reducers/ui.js
+++ b/lib/reducers/ui.js
@@ -175,6 +175,7 @@ const reducer = (state = initial, action) => {
 
     case SESSION_ADD:
       state_ = state.merge({
+        activeUid: action.uid,
         openAt: {
           [action.uid]: Date.now()
         }


### PR DESCRIPTION
This fixes a regression where the tab activity highlighter would trigger even if you were currently focusing that tab.